### PR TITLE
Support abstract components

### DIFF
--- a/compiler-tests/src/test/kotlin/me/tatarka/inject/test/FailureTest.kt
+++ b/compiler-tests/src/test/kotlin/me/tatarka/inject/test/FailureTest.kt
@@ -24,7 +24,7 @@ class FailureTest(private val target: Target) {
     }
 
     @Test
-    fun fails_if_module_is_not_abstract() {
+    fun fails_if_component_is_not_abstract() {
         assertThat {
             projectCompiler.source(
                 "test.kt", """
@@ -37,7 +37,7 @@ class FailureTest(private val target: Target) {
     }
 
     @Test
-    fun fails_if_module_is_private() {
+    fun fails_if_component_is_private() {
         assertThat {
             projectCompiler.source(
                 "test.kt", """
@@ -78,7 +78,7 @@ class FailureTest(private val target: Target) {
                     }
                 """.trimIndent()
             ).compile()
-        }.isFailure().output().contains("@Provides method must not be abstract")
+        }.isFailure().output().contains("@Provides method must have a concrete implementation")
     }
 
     @Test
@@ -133,7 +133,7 @@ class FailureTest(private val target: Target) {
     }
 
     @Test
-    fun fails_if_module_does_not_have_scope_to_provide_dependency() {
+    fun fails_if_component_does_not_have_scope_to_provide_dependency() {
         assertThat {
             projectCompiler.source(
                 "test.kt", """
@@ -149,6 +149,6 @@ class FailureTest(private val target: Target) {
                     }
                 """.trimIndent()
             ).compile()
-        }.isFailure().output().contains("Cannot find module with scope: @MyScope to inject Foo")
+        }.isFailure().output().contains("Cannot find component with scope: @MyScope to inject Foo")
     }
 }

--- a/integration-tests/src/test/kotlin/me/tatarka/inject/test/AbstractComponentTest.kt
+++ b/integration-tests/src/test/kotlin/me/tatarka/inject/test/AbstractComponentTest.kt
@@ -1,0 +1,60 @@
+package me.tatarka.inject.test
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import me.tatarka.inject.annotations.Component
+import me.tatarka.inject.annotations.Provides
+import kotlin.test.Test
+
+abstract class AbstractParentComponent {
+    @Provides
+    abstract fun foo(): NamedFoo
+}
+
+@Component abstract class ParentComponentImpl1 : AbstractParentComponent() {
+    override fun foo(): NamedFoo = NamedFoo("parent1")
+}
+
+@Component abstract class ParentComponentImpl2 : AbstractParentComponent() {
+    override fun foo(): NamedFoo = NamedFoo("parent2")
+}
+
+@Component abstract class AbstractParentChildComponent(@Component val parent: AbstractParentComponent) {
+    abstract val foo: NamedFoo
+}
+
+@CustomScope
+abstract class ScopedAbstractParentComponent
+
+@Component abstract class ScopedParentComponentImpl1 : ScopedAbstractParentComponent()
+
+@Component abstract class ScopedParentComponentImpl2 : ScopedAbstractParentComponent()
+
+@Component abstract class ScopedAbstractParentChildComponent(@Component val parent: ScopedAbstractParentComponent) {
+    abstract val bar: CustomScopeBar
+}
+
+class AbstractComponentTest {
+    @Test
+    fun generates_a_component_that_provides_a_dep_from_an_abstract_parent_component() {
+        val parent1 = ParentComponentImpl1::class.create()
+        val parent2 = ParentComponentImpl2::class.create()
+        val component1 = AbstractParentChildComponent::class.create(parent1)
+        val component2 = AbstractParentChildComponent::class.create(parent2)
+
+        assertThat(component1.foo.name).isEqualTo("parent1")
+        assertThat(component2.foo.name).isEqualTo("parent2")
+    }
+
+    @Test
+    fun generates_a_component_that_provides_a_dep_from_an_abstract_scoped_component() {
+        val parent1 = ScopedParentComponentImpl1::class.create()
+        val parent2 = ScopedParentComponentImpl2::class.create()
+        val component1 = ScopedAbstractParentChildComponent::class.create(parent1)
+        val component2 = ScopedAbstractParentChildComponent::class.create(parent2)
+
+        assertThat(component1.bar).isNotNull()
+        assertThat(component2.bar).isNotNull()
+    }
+}

--- a/integration-tests/src/test/kotlin/me/tatarka/inject/test/Models.kt
+++ b/integration-tests/src/test/kotlin/me/tatarka/inject/test/Models.kt
@@ -1,6 +1,7 @@
 package me.tatarka.inject.test
 
 import me.tatarka.inject.annotations.Inject
+import me.tatarka.inject.annotations.Scope
 
 interface IFoo
 
@@ -9,3 +10,14 @@ interface IFoo
 @Inject class Bar(val foo: Foo)
 
 class NamedFoo(val name: String)
+
+@Scope
+annotation class CustomScope
+
+var customScopeBarConstructorCount = 0
+
+@CustomScope @Inject class CustomScopeBar {
+    init {
+        customScopeBarConstructorCount++
+    }
+}

--- a/integration-tests/src/test/kotlin/me/tatarka/inject/test/NestedComponentTest.kt
+++ b/integration-tests/src/test/kotlin/me/tatarka/inject/test/NestedComponentTest.kt
@@ -19,23 +19,6 @@ import kotlin.test.Test
     abstract val foo: NamedFoo
 }
 
-//abstract class AbstractParentComponent {
-//    @Provides
-//    abstract fun foo(): NamedFoo
-//}
-//
-//@Component abstract class ParentComponentImpl1 : AbstractParentComponent() {
-//    override fun foo(): NamedFoo = NamedFoo("parent1")
-//}
-//
-//@Component abstract class ParentComponentImpl2 : AbstractParentComponent() {
-//    override fun foo(): NamedFoo = NamedFoo("parent2")
-//}
-//
-//@Component abstract class AbstractParentChildComponent(@Component val parent: AbstractParentComponent) {
-//    abstract val foo: NamedFoo
-//}
-
 class NestedComponentTest {
     @Test
     fun generates_a_component_that_provides_a_dep_from_a_parent_component() {

--- a/integration-tests/src/test/kotlin/me/tatarka/inject/test/ScopeTest.kt
+++ b/integration-tests/src/test/kotlin/me/tatarka/inject/test/ScopeTest.kt
@@ -6,17 +6,6 @@ import me.tatarka.inject.annotations.*
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 
-@Scope
-annotation class CustomScope
-
-var customScopeBarConstructorCount = 0
-
-@CustomScope @Inject class CustomScopeBar {
-    init {
-        customScopeBarConstructorCount++
-    }
-}
-
 @CustomScope @Component abstract class CustomScopeConstructorComponent {
     abstract val bar: CustomScopeBar
 }

--- a/kotlin-inject-compiler-core/src/main/kotlin/me/tatarka/inject/compiler/Ast.kt
+++ b/kotlin-inject-compiler-core/src/main/kotlin/me/tatarka/inject/compiler/Ast.kt
@@ -80,6 +80,8 @@ sealed class AstMethod : AstElement() {
 
     abstract val receiverParameterType: AstType?
 
+    abstract fun overrides(other: AstMethod): Boolean
+
     abstract val returnType: AstType
 
     abstract fun returnTypeFor(enclosingClass: AstClass): AstType

--- a/kotlin-inject-compiler-kapt/src/main/kotlin/me/tatarka/inject/compiler/kapt/InjectCompiler.kt
+++ b/kotlin-inject-compiler-kapt/src/main/kotlin/me/tatarka/inject/compiler/kapt/InjectCompiler.kt
@@ -9,16 +9,19 @@ import javax.lang.model.element.TypeElement
 class InjectCompiler : BaseInjectCompiler() {
 
     override fun process(elements: Set<TypeElement>, env: RoundEnvironment): Boolean {
+        val generator = InjectGenerator(this, options)
+
         for (element in env.getElementsAnnotatedWith(Component::class.java)) {
             if (element !is TypeElement) continue
-            val scopeType = element.scopeType()
-            // Only deal with non-scoped components
-            if (scopeType != null) continue
 
-            val generator = InjectGenerator(this, options)
+            val astClass = element.toAstClass()
+            val scopeClass = with(generator) {
+                astClass.scopeClass()
+            }
+            // Only deal with non-scoped components
+            if (scopeClass != null) continue
 
             try {
-                val astClass = element.toAstClass()
                 val file = generator.generate(astClass)
                 file.writeTo(filer)
             } catch (e: FailedToGenerateException) {

--- a/kotlin-inject-compiler-kapt/src/main/kotlin/me/tatarka/inject/compiler/kapt/Util.kt
+++ b/kotlin-inject-compiler-kapt/src/main/kotlin/me/tatarka/inject/compiler/kapt/Util.kt
@@ -20,8 +20,6 @@ fun <T : Annotation> Element.typeAnnotatedWith(type: KClass<T>) =
 
 inline fun <reified T : Annotation> Element.typeAnnotatedWith() = typeAnnotatedWith(T::class)
 
-fun Element.scopeType(): TypeElement? = typeAnnotatedWith<Scope>()
-
 fun TypeName.javaToKotlinType(): TypeName = if (this is ParameterizedTypeName) {
     (rawType.javaToKotlinType() as ClassName).parameterizedBy(
         *typeArguments.map { it.javaToKotlinType() }.toTypedArray()

--- a/kotlin-inject-compiler-ksp/src/main/kotlin/me/tatarka/inject/compiler/ksp/KSAst.kt
+++ b/kotlin-inject-compiler-ksp/src/main/kotlin/me/tatarka/inject/compiler/ksp/KSAst.kt
@@ -169,6 +169,11 @@ private class KSAstFunction(provider: KSAstProvider, override val declaration: K
     override val receiverParameterType: AstType?
         get() = declaration.extensionReceiver?.let { KSAstType(this, it) }
 
+    override fun overrides(other: AstMethod): Boolean {
+        require(other is KSAstFunction)
+        return declaration.overrides(other.declaration)
+    }
+
     override val returnType: AstType
         get() = KSAstType(this, declaration.returnType!!)
 
@@ -193,6 +198,11 @@ private class KSAstProperty(provider: KSAstProvider, override val declaration: K
 
     override val receiverParameterType: AstType?
         get() = declaration.extensionReceiver?.let { KSAstType(this, it) }
+
+    override fun overrides(other: AstMethod): Boolean {
+        require(other is KSAstProperty)
+        return false //TODO?
+    }
 
     override val returnType: AstType
         get() = KSAstType(this, declaration.type!!)

--- a/kotlin-inject-compiler-ksp/src/main/kotlin/me/tatarka/inject/compiler/ksp/Util.kt
+++ b/kotlin-inject-compiler-ksp/src/main/kotlin/me/tatarka/inject/compiler/ksp/Util.kt
@@ -28,8 +28,6 @@ fun KSAnnotated.getAnnotation(type: KClass<out Annotation>): KSAnnotation? {
     return annotations.find { it.annotationType.resolve()?.declaration?.qualifiedName?.asString() == type.qualifiedName }
 }
 
-fun KSClassDeclaration.scopeType() = typeAnnotatedWith<Scope>()
-
 fun KSDeclaration.asClassName(): ClassName {
     val name = qualifiedName!!
     return ClassName(name.getQualifier(), name.getShortName())


### PR DESCRIPTION
You can define `@Provides` and `@Scope` annotations on an abstract
class/interface that components implement and pass this as a
`@Component` dependency to another component. This allows you to swap
out implementations for testing.