### PR TITLE
Allow bounded generic provides methods

### DIFF
--- a/integration-tests/ksp/src/test/kotlin/me/tatarka/inject/test/ReifiedProvidesTest.kt
+++ b/integration-tests/ksp/src/test/kotlin/me/tatarka/inject/test/ReifiedProvidesTest.kt
@@ -1,0 +1,53 @@
+package me.tatarka.inject.test
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import me.tatarka.inject.annotations.Component
+import me.tatarka.inject.annotations.Provides
+import kotlin.reflect.KClass
+import kotlin.reflect.full.createInstance
+import kotlin.test.Test
+
+data class FooClass<T>(val fooClass: Any?)
+
+@Component abstract class ReifiedProvidesComponent {
+    abstract val foo: FooClass<Foo>
+
+    abstract val bar: FooClass<Bar>
+
+    @Provides
+    inline fun <reified T: IFoo> providesFoo(): FooClass<T> = FooClass(T::class)
+}
+
+class ReflectFoo: IFoo
+
+class ReflectBar : IFoo
+
+@Component abstract class ReflectProvidesComponent {
+    abstract val foo: ReflectFoo
+
+    abstract val bar: ReflectBar
+
+    @Provides
+    inline fun <reified T: IFoo> providesFoo(): T = T::class.createInstance()
+}
+
+class ReifiedProvidesTest {
+
+    @Test
+    fun generates_a_component_provides_a_class_from_a_bounded_reified_generic() {
+        val component = ReifiedProvidesComponent::class.create()
+
+        assertThat(component.foo.fooClass).isEqualTo(Foo::class)
+        assertThat(component.bar.fooClass).isEqualTo(Bar::class)
+    }
+
+    @Test
+    fun generates_a_component_provides_an_instance_from_a_bounded_reified_generic() {
+        val component = ReflectProvidesComponent::class.create()
+
+        assertThat(component.foo).isNotNull()
+        assertThat(component.bar).isNotNull()
+    }
+}

--- a/kotlin-inject-compiler-core/src/main/kotlin/me/tatarka/inject/compiler/Ast.kt
+++ b/kotlin-inject-compiler-core/src/main/kotlin/me/tatarka/inject/compiler/Ast.kt
@@ -1,8 +1,10 @@
 package me.tatarka.inject.compiler
 
-import com.squareup.kotlinpoet.*
-import kotlin.contracts.InvocationKind
-import kotlin.contracts.contract
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.MemberName
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.TypeSpec
 import kotlin.reflect.KClass
 
 interface AstProvider {
@@ -31,7 +33,8 @@ interface Messenger {
 sealed class AstElement : AstAnnotated {
     inline fun <reified T : Annotation> hasAnnotation() = hasAnnotation(T::class.qualifiedName!!)
 
-    inline fun <reified T : Annotation> annotationAnnotatedWith(): AstAnnotation? = annotationAnnotatedWith(T::class.qualifiedName!!)
+    inline fun <reified T : Annotation> annotationAnnotatedWith(): AstAnnotation? =
+        annotationAnnotatedWith(T::class.qualifiedName!!)
 }
 
 interface AstAnnotated {
@@ -86,6 +89,8 @@ sealed class AstMethod : AstElement(), AstHasModifiers {
     abstract fun overrides(other: AstMethod): Boolean
 
     abstract val returnType: AstType
+
+    abstract val typeParameters: List<AstTypeParam>
 
     abstract fun returnTypeFor(enclosingClass: AstClass): AstType
 
@@ -152,7 +157,13 @@ abstract class AstType : AstElement() {
 
     abstract fun isUnit(): Boolean
 
+    abstract fun isAny(): Boolean
+
     abstract fun isFunction(): Boolean
+
+    abstract val isTypeParam: Boolean
+
+    abstract val isGeneric: Boolean
 
     abstract fun isTypeAlis(): Boolean
 
@@ -198,6 +209,16 @@ abstract class AstParam : AstElement() {
     override fun toString(): String {
         return "$name: $type"
     }
+}
+
+abstract class AstTypeParam : AstElement() {
+    abstract val name: String
+
+    abstract val bounds: List<AstType>
+
+    abstract override fun equals(other: Any?): Boolean
+
+    abstract override fun hashCode(): Int
 }
 
 interface AstHasModifiers {

--- a/kotlin-inject-compiler-kapt/src/main/kotlin/me/tatarka/inject/compiler/kapt/Util.kt
+++ b/kotlin-inject-compiler-kapt/src/main/kotlin/me/tatarka/inject/compiler/kapt/Util.kt
@@ -30,6 +30,8 @@ import javax.lang.model.type.ArrayType
 import javax.lang.model.type.DeclaredType
 import javax.lang.model.type.TypeKind
 import javax.lang.model.type.TypeMirror
+import javax.lang.model.type.TypeVariable
+import javax.lang.model.type.WildcardType
 
 fun Element.hasAnnotation(className: String): Boolean {
     return annotationMirrors.any { it.annotationType.toString() == className }
@@ -248,6 +250,11 @@ private fun KmType.isSuspendFunction(): Boolean {
             arguments[arguments.size - 2].type?.classifier?.name == "kotlin/coroutines/Continuation"
 }
 
+fun KmType.isGeneric(): Boolean {
+    return classifier is KmClassifier.TypeParameter
+            || arguments.any { it.type?.isGeneric() == true }
+}
+
 fun AnnotationMirror.eqv(other: AnnotationMirror): Boolean {
     if (annotationType != other.annotationType) {
         return false
@@ -321,3 +328,8 @@ inline fun KmProperty.isAbstract() = Flag.Common.IS_ABSTRACT(flags)
 inline fun KmProperty.isPrivate() = Flag.Common.IS_PRIVATE(flags)
 
 inline fun KmConstructor.isVal() = Flag.Constructor.IS_PRIMARY
+
+fun TypeMirror.isGeneric(): Boolean =
+    this is TypeVariable ||
+            this is WildcardType ||
+            (this is DeclaredType && this.typeArguments.any { it.isGeneric() })

--- a/kotlin-inject-compiler-ksp/src/main/kotlin/me/tatarka/inject/compiler/ksp/Util.kt
+++ b/kotlin-inject-compiler-ksp/src/main/kotlin/me/tatarka/inject/compiler/ksp/Util.kt
@@ -171,3 +171,6 @@ fun KSType.isSuspendingFunction(): Boolean {
     val name = declaration.qualifiedName ?: return false
     return name.getQualifier() == "kotlin.coroutines" && name.getShortName().matches(SUSPEND_FUNCTION)
 }
+
+fun KSType.isGeneric(): Boolean =
+    declaration is KSTypeParameter || arguments.any { it.type?.resolve()?.isGeneric() == true }


### PR DESCRIPTION
This allows generic construction which can be useful in some cases, ex:
retrofit.

```kotlin
@Compnation abstract class NetworkComponent {
    @Provides
    inline fun <reified T: Service> retrofitService(retrofit: Retrofit): T = retrofit.create<T>()
}
```

A type bounds other than Any is required, otherwise the provides would be
avaialble for every injection which could easily hide other errors until
runtime.

Note: reified inline provides methods only work in the ksp backend because the
method is not accesable from kapt.