### PR TITLE
Support default args in component constructors

### DIFF
--- a/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/DefaultArgTest.kt
+++ b/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/DefaultArgTest.kt
@@ -1,0 +1,23 @@
+package me.tatarka.inject.test
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import me.tatarka.inject.annotations.Component
+import kotlin.test.Test
+
+@Component abstract class DefaultArgComponent(val required1: String, val optional: String = "default", val required2: String)
+
+class DefaultArgTest {
+    @Test
+    fun generates_a_component_with_a_create_that_skips_default_args() {
+        val componentFull = DefaultArgComponent::class.create("one", "two", "three")
+        val componentDefault = DefaultArgComponent::class.create("one", "three")
+
+        assertThat(componentFull.required1).isEqualTo("one")
+        assertThat(componentFull.optional).isEqualTo("two")
+        assertThat(componentFull.required2).isEqualTo("three")
+        assertThat(componentDefault.required1).isEqualTo("one")
+        assertThat(componentDefault.optional).isEqualTo("default")
+        assertThat(componentDefault.required2).isEqualTo("three")
+    }
+}

--- a/kotlin-inject-compiler-core/src/main/kotlin/me/tatarka/inject/compiler/Ast.kt
+++ b/kotlin-inject-compiler-core/src/main/kotlin/me/tatarka/inject/compiler/Ast.kt
@@ -195,6 +195,8 @@ abstract class AstParam : AstElement() {
 
     abstract val isPrivate: Boolean
 
+    abstract val hasDefault: Boolean
+
     abstract fun asParameterSpec(): ParameterSpec
 
     override fun toString(): String {
@@ -206,6 +208,3 @@ interface AstHasModifiers {
     val isPrivate: Boolean
     val isAbstract: Boolean
 }
-
-fun ParameterSpec.Companion.parametersOf(constructor: AstConstructor) =
-    constructor.parameters.map { it.asParameterSpec() }

--- a/kotlin-inject-compiler-kapt/src/main/kotlin/me/tatarka/inject/compiler/kapt/ModelAst.kt
+++ b/kotlin-inject-compiler-kapt/src/main/kotlin/me/tatarka/inject/compiler/kapt/ModelAst.kt
@@ -636,6 +636,9 @@ private class ModelAstParam(
         return parent.properties.find { it.name == param.name }?.isPrivate() ?: false
     }
 
+    override val hasDefault: Boolean
+        get() = kmValueParameter?.hasDefault() ?: false
+
     override fun asParameterSpec(): ParameterSpec {
         return ParameterSpec(name, type.asTypeName())
     }

--- a/kotlin-inject-compiler-kapt/src/main/kotlin/me/tatarka/inject/compiler/kapt/Util.kt
+++ b/kotlin-inject-compiler-kapt/src/main/kotlin/me/tatarka/inject/compiler/kapt/Util.kt
@@ -7,13 +7,7 @@ import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.asTypeName
-import kotlinx.metadata.Flag
-import kotlinx.metadata.KmClass
-import kotlinx.metadata.KmClassifier
-import kotlinx.metadata.KmConstructor
-import kotlinx.metadata.KmFunction
-import kotlinx.metadata.KmProperty
-import kotlinx.metadata.KmType
+import kotlinx.metadata.*
 import kotlinx.metadata.jvm.JvmMethodSignature
 import kotlinx.metadata.jvm.KotlinClassHeader
 import kotlinx.metadata.jvm.KotlinClassMetadata
@@ -323,3 +317,5 @@ inline fun KmProperty.isAbstract() = Flag.Common.IS_ABSTRACT(flags)
 inline fun KmProperty.isPrivate() = Flag.Common.IS_PRIVATE(flags)
 
 inline fun KmConstructor.isVal() = Flag.Constructor.IS_PRIMARY
+
+inline fun KmValueParameter.hasDefault() = Flag.ValueParameter.DECLARES_DEFAULT_VALUE(flags)

--- a/kotlin-inject-compiler-ksp/src/main/kotlin/me/tatarka/inject/compiler/ksp/KSAst.kt
+++ b/kotlin-inject-compiler-ksp/src/main/kotlin/me/tatarka/inject/compiler/ksp/KSAst.kt
@@ -440,6 +440,9 @@ private class KSAstParam(
     override val isPrivate: Boolean
         get() = parentClass?.getDeclaredProperties()?.find { it.simpleName == declaration.name }?.isPrivate() ?: false
 
+    override val hasDefault: Boolean
+        get() = declaration.hasDefault
+
     override fun asParameterSpec(): ParameterSpec {
         return ParameterSpec.builder(name, type.asTypeName())
             .build()


### PR DESCRIPTION
Due to a limitation in kapt/ksp we can't read default values to declare them
ourselves. This means we need to generate create/constructor for each set of
params we want to pass. For now we only create 2, one with all the params and
one with the default params omitted.

Fixes #50