### PR TITLE
Support annotating constructors (primary and secondary) with `@Inject`

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,8 +362,8 @@ You can provide some additional options to the processor.
 - `me.tatarka.inject.generateCompanionExtensions=true`
 
   This will generate the `create()` methods on the companion object instead of the component's class. This allows you to do
-  `MyComponent.create()` instead of `MyComponent::class.create()`. However, due to a kotlin limitiation you will have to
-  explitilcy specify a companion object for your component.
+  `MyComponent.create()` instead of `MyComponent::class.create()`. However, due to a kotlin limitation you will have to
+  explicitly specify a companion object for your component.
   
   ```kotlin
   @Component abstract class MyComponent {

--- a/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/InjectConstructorTest.kt
+++ b/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/InjectConstructorTest.kt
@@ -1,0 +1,39 @@
+package me.tatarka.inject.test
+
+import assertk.assertThat
+import assertk.assertions.isNotNull
+import me.tatarka.inject.annotations.Component
+import me.tatarka.inject.annotations.Inject
+import org.junit.Test
+
+@Component
+abstract class InjectCtorComponent {
+
+    abstract val primaryInject: FooWithPrimaryInject
+
+    abstract val secondaryInject: FooWithSecondaryInject
+}
+
+class FooWithPrimaryInject @Inject constructor()
+
+class FooWithSecondaryInject(private val prop: String) {
+
+    @Inject constructor() : this("prop")
+}
+
+class InjectConstructorTest {
+
+    @Test
+    fun class_with_inject_annotated_primary_constructor_can_be_provided() {
+        val component = InjectCtorComponent::class.create()
+
+        assertThat(component.primaryInject).isNotNull()
+    }
+
+    @Test
+    fun class_with_inject_annotated_secondary_constructor_can_be_provided() {
+        val component = InjectCtorComponent::class.create()
+
+        assertThat(component.secondaryInject).isNotNull()
+    }
+}

--- a/kotlin-inject-compiler-core/src/main/kotlin/me/tatarka/inject/compiler/Ast.kt
+++ b/kotlin-inject-compiler-core/src/main/kotlin/me/tatarka/inject/compiler/Ast.kt
@@ -1,8 +1,6 @@
 package me.tatarka.inject.compiler
 
 import com.squareup.kotlinpoet.*
-import kotlin.contracts.InvocationKind
-import kotlin.contracts.contract
 import kotlin.reflect.KClass
 
 interface AstProvider {
@@ -57,6 +55,8 @@ abstract class AstClass : AstElement(), AstHasModifiers {
     abstract val superTypes: List<AstClass>
 
     abstract val primaryConstructor: AstConstructor?
+
+    abstract val constructors: List<AstConstructor>
 
     abstract val methods: List<AstMethod>
 

--- a/kotlin-inject-compiler-core/src/main/kotlin/me/tatarka/inject/compiler/TypeCollector.kt
+++ b/kotlin-inject-compiler-core/src/main/kotlin/me/tatarka/inject/compiler/TypeCollector.kt
@@ -230,7 +230,8 @@ class TypeCollector private constructor(private val provider: AstProvider, priva
             return result
         }
         val astClass = key.type.toAstClass()
-        if (astClass.isInject(options)) {
+        val injectCtor = astClass.findInjectConstructors(messenger, options)
+        if (injectCtor != null) {
             val scope = astClass.scopeType(options)
             val scopedComponent = if (scope != null) scopedAccessors[scope] else null
             if (scope != null && scopedComponent == null) {
@@ -238,7 +239,7 @@ class TypeCollector private constructor(private val provider: AstProvider, priva
                 return null
             }
             return TypeCreator.Constructor(
-                astClass.primaryConstructor!!,
+                injectCtor,
                 accessor = scopedComponent?.accessor,
                 scopedComponent = scopedComponent?.type
             )

--- a/kotlin-inject-compiler-kapt/src/main/kotlin/me/tatarka/inject/compiler/kapt/Util.kt
+++ b/kotlin-inject-compiler-kapt/src/main/kotlin/me/tatarka/inject/compiler/kapt/Util.kt
@@ -316,6 +316,6 @@ inline fun KmProperty.isAbstract() = Flag.Common.IS_ABSTRACT(flags)
 
 inline fun KmProperty.isPrivate() = Flag.Common.IS_PRIVATE(flags)
 
-inline fun KmConstructor.isVal() = Flag.Constructor.IS_PRIMARY
+inline fun KmConstructor.isPrimary() = Flag.Constructor.IS_PRIMARY(flags)
 
 inline fun KmValueParameter.hasDefault() = Flag.ValueParameter.DECLARES_DEFAULT_VALUE(flags)

--- a/kotlin-inject-compiler-ksp/src/main/kotlin/me/tatarka/inject/compiler/ksp/KSAst.kt
+++ b/kotlin-inject-compiler-ksp/src/main/kotlin/me/tatarka/inject/compiler/ksp/KSAst.kt
@@ -1,5 +1,6 @@
 package me.tatarka.inject.compiler.ksp
 
+import com.google.devtools.ksp.*
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.ParameterSpec
@@ -18,11 +19,6 @@ import me.tatarka.inject.compiler.AstProperty
 import me.tatarka.inject.compiler.AstProvider
 import me.tatarka.inject.compiler.AstType
 import me.tatarka.inject.compiler.Messenger
-import com.google.devtools.ksp.findActualType
-import com.google.devtools.ksp.getDeclaredFunctions
-import com.google.devtools.ksp.getDeclaredProperties
-import com.google.devtools.ksp.isAbstract
-import com.google.devtools.ksp.isPrivate
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
@@ -175,6 +171,9 @@ private class KSAstClass(provider: KSAstProvider, override val declaration: KSCl
         get() {
             return declaration.primaryConstructor?.let { KSAstConstructor(this, this, it) }
         }
+
+    override val constructors: List<AstConstructor>
+        get() = declaration.getConstructors().map { KSAstConstructor(this, this, it) }
 
     override val methods: List<AstMethod>
         get() {

--- a/kotlin-inject-runtime/src/main/kotlin/me/tatarka/inject/annotations/Annotations.kt
+++ b/kotlin-inject-runtime/src/main/kotlin/me/tatarka/inject/annotations/Annotations.kt
@@ -4,7 +4,7 @@ import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.annotation.AnnotationTarget.*
 
 @Retention(RUNTIME)
-@Target(CLASS, FUNCTION)
+@Target(CLASS, FUNCTION, CONSTRUCTOR)
 annotation class Inject
 
 @Retention(RUNTIME)


### PR DESCRIPTION
Fixes https://github.com/evant/kotlin-inject/issues/10.