### PR TITLE
Add detekt and ktlint static checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,14 @@ jobs:
       - gradle/with_cache:
           steps:
             - run:
-                name: Run Tests
-                command: ./gradlew test
+                name: Run Tests and Checks
+                command: ./gradlew check
+            - run:
+                name: Collect Detekt Reports
+                command: cp -vr build/reports detekt
+                when: on_fail
+            - store_artifacts:
+                path: detekt
             - deploy:
                 command: |
                   if [ "${CIRCLE_BRANCH}" == "main" ]; then

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.{kt,kts}]
+max_line_length = 120
+disabled_rules = final-newline,import-ordering

--- a/.static/detekt-config.yml
+++ b/.static/detekt-config.yml
@@ -1,0 +1,167 @@
+build:
+  maxIssues: 0
+
+console-reports:
+  exclude:
+    - "ProjectStatisticsReport"
+    - "ComplexityReport"
+    - "NotificationReport"
+
+complexity:
+  LongParameterList:
+    active: false
+  LargeClass:
+    excludes: "**/test/**,**/integration-tests/**,**/*.Test.kt"
+  ReplaceSafeCallChainWithRun:
+    active: true
+  TooManyFunctions:
+    active: false
+
+formatting:
+  FinalNewline:
+    active: false
+  AnnotationSpacing:
+    active: true
+    autoCorrect: true
+
+naming:
+  ConstructorParameterNaming:
+    privateParameterPattern: "(_)?[a-z][A-Za-z0-9]*"
+  TopLevelPropertyNaming:
+    active: false
+  VariableNaming:
+    active: true
+    variablePattern: "[a-z][A-Za-z0-9]*"
+    privateVariablePattern: "(_)?[a-z][A-Za-z0-9]*"
+    excludeClassPattern: "$^"
+  NonBooleanPropertyPrefixedWithIs:
+    active: true
+    excludes: "**/test/**,**/integration-tests/**,**/*.Test.kt"
+  FunctionNaming:
+    ignoreAnnotated: ["Benchmark"]
+
+performance:
+  SpreadOperator:
+    active: false
+
+potential-bugs:
+  EqualsAlwaysReturnsTrueOrFalse:
+    active: true
+  InvalidRange:
+    active: true
+  IteratorHasNextCallsNextMethod:
+    active: true
+  IteratorNotThrowingNoSuchElementException:
+    active: true
+  UnconditionalJumpStatementInLoop:
+    active: true
+  UselessPostfixExpression:
+    active: true
+  WrongEqualsTypeParameter:
+    active: true
+  Deprecation:
+    active: true
+  HasPlatformType:
+    active: true
+  MissingWhenCase:
+    active: true
+  NullableToStringCall:
+    active: true
+  RedundantElseInWhen:
+    active: true
+  UnnecessaryNotNullOperator:
+    active: true
+  UnnecessarySafeCall:
+    active: true
+
+style:
+  ReturnCount:
+    active: false
+  LoopWithTooManyJumpStatements:
+    active: true
+  ForbiddenComment:
+    active: false
+  MagicNumber:
+    ignoreEnums: true
+    ignorePropertyDeclaration: true
+  MayBeConst:
+    active: true
+  NewLineAtEndOfFile:
+    active: false
+  RedundantVisibilityModifierRule:
+    active: true
+  SpacingBetweenPackageAndImports:
+    active: true
+  TrailingWhitespace:
+    active: true
+  UnnecessaryAbstractClass:
+    active: true
+    excludeAnnotatedClasses: ["Component"]
+    excludes: "**/test/**,**/integration-tests/**,**/*.Test.kt"
+  UnnecessaryApply:
+    active: true
+  UnnecessaryInheritance:
+    active: true
+  UnnecessaryParentheses:
+    active: true
+  UntilInsteadOfRangeTo:
+    active: true
+  UnusedImports:
+    active: true
+  UnusedPrivateMember:
+    active: true
+    excludes: "**/test/**,**/integration-tests/**,**/*.Test.kt"
+  UtilityClassWithPublicConstructor:
+    active: true
+    excludes: "**/test/**,**/integration-tests/**,**/*.Test.kt"
+  CollapsibleIfStatements:
+    active: true
+  EqualsNullCall:
+    active: true
+  EqualsOnSignatureLine:
+    active: true
+  ExplicitItLambdaParameter:
+    active: true
+  ForbiddenVoid:
+    active: true
+    ignoreOverridden: false
+    ignoreUsageInGenerics: false
+  LibraryCodeMustSpecifyReturnType:
+    active: true
+  MandatoryBracesIfStatements:
+    active: true
+  PreferToOverPairSyntax:
+    active: true
+  OptionalWhenBraces:
+    active: true
+  ProtectedMemberInFinalClass:
+    active: true
+  RedundantExplicitType:
+    active: true
+  SafeCast:
+    active: true
+  UseArrayLiteralsInAnnotations:
+    active: true
+  UseEmptyCounterpart:
+    active: true
+  UseCheckOrError:
+    active: true
+  UseRequire:
+    active: true
+  UselessCallOnNotNull:
+    active: true
+  VarCouldBeVal:
+    active: true
+  UseCheckNotNull:
+    active: true
+  UseRequireNotNull:
+    active: true
+
+coroutines:
+  active: true
+  GlobalCoroutineUsage:
+    active: true
+  RedundantSuspendModifier:
+    active: true
+  SuspendFunWithFlowReturnType:
+    active: true

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,11 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.4.0' apply false
     id 'symbol-processing' version "$ksp_version" apply false
+    id "io.gitlab.arturbosch.detekt" version "1.14.2"
+}
+
+repositories {
+    jcenter()
 }
 
 subprojects {
@@ -8,4 +13,28 @@ subprojects {
         google()
         mavenCentral()
     }
+    afterEvaluate { project ->
+        project.tasks.findByName("check")?.dependsOn rootProject.tasks["detektAll"]
+    }
+}
+
+task detektAll(type: io.gitlab.arturbosch.detekt.Detekt) {
+    parallel = true
+    failFast = false
+    buildUponDefaultConfig = true
+    source = files(projectDir)
+    config.from = project.file(".static/detekt-config.yml")
+    include("**/*.kt")
+    exclude("**/build/**")
+    reports {
+        html {
+            enabled = true
+            destination = project.file("build/reports/detekt.html")
+        }
+        xml.enabled = false
+    }
+}
+
+dependencies {
+    detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:1.14.2"
 }

--- a/compiler-tests/src/main/kotlin/me/tatarka/inject/Profile.kt
+++ b/compiler-tests/src/main/kotlin/me/tatarka/inject/Profile.kt
@@ -3,18 +3,23 @@ package me.tatarka.inject
 import me.tatarka.inject.compiler.Profiler
 
 fun main() {
-    val compiler = ProjectCompiler(Target.ksp, profiler = object : Profiler {
-        override fun onStart() {
-            println("generate start")
-            readLine()
-        }
+    val compiler = ProjectCompiler(
+        Target.KSP,
+        profiler = object : Profiler {
+            override fun onStart() {
+                println("generate start")
+                readLine()
+            }
 
-        override fun onStop() {
-            println("generate end")
-            readLine()
+            override fun onStop() {
+                println("generate end")
+                readLine()
+            }
         }
-    })
-    compiler.source("MyComponent.kt", """
+    )
+    compiler.source(
+        "MyComponent.kt",
+        """
         import me.tatarka.inject.annotations.Component
         import me.tatarka.inject.annotations.Provides
         
@@ -61,7 +66,8 @@ fun main() {
         interface I4: I5 { val foo4: S4 }
         
         interface I5 { val foo5: S5 }
-    """.trimIndent())
+        """.trimIndent()
+    )
 
     compiler.compile()
 }

--- a/compiler-tests/src/main/kotlin/me/tatarka/inject/ProjectCompiler.kt
+++ b/compiler-tests/src/main/kotlin/me/tatarka/inject/ProjectCompiler.kt
@@ -1,6 +1,9 @@
 package me.tatarka.inject
 
-import com.tschuchort.compiletesting.*
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import com.tschuchort.compiletesting.kspArgs
+import com.tschuchort.compiletesting.symbolProcessors
 import me.tatarka.inject.compiler.Options
 import me.tatarka.inject.compiler.Profiler
 import me.tatarka.inject.compiler.kapt.InjectCompiler
@@ -39,13 +42,13 @@ class ProjectCompiler(
             root?.let { workingDir = it }
             inheritClassPath = true
             when (target) {
-                Target.kapt -> {
+                Target.KAPT -> {
                     options?.let {
                         kaptArgs.putAll(it.toMap())
                     }
                     annotationProcessors = listOf(InjectCompiler(profiler))
                 }
-                Target.ksp -> {
+                Target.KSP -> {
                     options?.let {
                         kspArgs.putAll(it.toMap())
                     }
@@ -56,12 +59,13 @@ class ProjectCompiler(
         System.setErr(oldErr)
 
         if (result.exitCode != KotlinCompilation.ExitCode.OK) {
+            @Suppress("TooGenericExceptionThrown")
             throw Exception(output.toString())
         }
     }
 }
 
 enum class Target {
-    kapt,
-    ksp
+    KAPT,
+    KSP
 }

--- a/compiler-tests/src/test/kotlin/me/tatarka/inject/test/FailureTest.kt
+++ b/compiler-tests/src/test/kotlin/me/tatarka/inject/test/FailureTest.kt
@@ -12,7 +12,6 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
-import kotlin.test.Ignore
 
 @RunWith(Parameterized::class)
 class FailureTest(val target: Target) {
@@ -38,7 +37,8 @@ class FailureTest(val target: Target) {
     fun fails_if_component_is_not_abstract() {
         assertThat {
             projectCompiler.source(
-                "MyComponent.kt", """
+                "MyComponent.kt",
+                """
                     import me.tatarka.inject.annotations.Component
                     
                     @Component class MyComponent
@@ -52,7 +52,8 @@ class FailureTest(val target: Target) {
     fun fails_if_component_is_private() {
         assertThat {
             projectCompiler.source(
-                "MyComponent.kt", """
+                "MyComponent.kt",
+                """
                     import me.tatarka.inject.annotations.Component
                     
                     @Component private abstract class MyComponent
@@ -66,7 +67,8 @@ class FailureTest(val target: Target) {
     fun fails_if_provides_is_private() {
         assertThat {
             projectCompiler.source(
-                "MyComponent.kt", """
+                "MyComponent.kt",
+                """
                     import me.tatarka.inject.annotations.Component
                     import me.tatarka.inject.annotations.Provides
                     
@@ -82,7 +84,8 @@ class FailureTest(val target: Target) {
     fun fails_if_provides_is_abstract() {
         assertThat {
             projectCompiler.source(
-                "MyComponent.kt", """
+                "MyComponent.kt",
+                """
                     import me.tatarka.inject.annotations.Component
                     import me.tatarka.inject.annotations.Provides
                     
@@ -99,7 +102,8 @@ class FailureTest(val target: Target) {
     fun fails_if_provides_returns_unit() {
         assertThat {
             projectCompiler.source(
-                "MyComponent.kt", """
+                "MyComponent.kt",
+                """
                     import me.tatarka.inject.annotations.Component
                     import me.tatarka.inject.annotations.Provides
                     
@@ -115,7 +119,8 @@ class FailureTest(val target: Target) {
     fun fails_if_the_same_type_is_provided_more_than_once() {
         assertThat {
             projectCompiler.source(
-                "MyComponent.kt", """
+                "MyComponent.kt",
+                """
                     import me.tatarka.inject.annotations.Component
                     import me.tatarka.inject.annotations.Provides
                     
@@ -133,7 +138,8 @@ class FailureTest(val target: Target) {
     fun fails_if_type_cannot_be_provided() {
         assertThat {
             projectCompiler.source(
-                "MyComponent.kt", """
+                "MyComponent.kt",
+                """
                     import me.tatarka.inject.annotations.Component
                     
                     @Component abstract class MyComponent {
@@ -149,7 +155,8 @@ class FailureTest(val target: Target) {
     fun fails_if_type_cannot_be_provided_to_constructor() {
         assertThat {
             projectCompiler.source(
-                "MyComponent.kt", """
+                "MyComponent.kt",
+                """
                     import me.tatarka.inject.annotations.Component
                     import me.tatarka.inject.annotations.Inject
                     
@@ -167,7 +174,8 @@ class FailureTest(val target: Target) {
     fun fails_if_inject_annotated_class_has_inject_annotated_constructors() {
         assertThat {
             projectCompiler.source(
-                "MyComponent.kt", """
+                "MyComponent.kt",
+                """
                     import me.tatarka.inject.annotations.Component
                     import me.tatarka.inject.annotations.Inject
                     
@@ -187,7 +195,8 @@ class FailureTest(val target: Target) {
     fun fails_if_class_has_multiple_inject_annotated_constructors() {
         assertThat {
             projectCompiler.source(
-                "MyComponent.kt", """
+                "MyComponent.kt",
+                """
                     import me.tatarka.inject.annotations.Component
                     import me.tatarka.inject.annotations.Inject
                     
@@ -210,7 +219,8 @@ class FailureTest(val target: Target) {
     fun fails_if_type_cannot_be_provided_to_provides() {
         assertThat {
             projectCompiler.source(
-                "MyComponent.kt", """
+                "MyComponent.kt",
+                """
                     import me.tatarka.inject.annotations.Component
                     import me.tatarka.inject.annotations.Provides
                     
@@ -231,7 +241,8 @@ class FailureTest(val target: Target) {
     fun fails_if_component_does_not_have_scope_to_provide_dependency() {
         assertThat {
             projectCompiler.source(
-                "MyComponent.kt", """
+                "MyComponent.kt",
+                """
                     import me.tatarka.inject.annotations.Component
                     import me.tatarka.inject.annotations.Scope
                     import me.tatarka.inject.annotations.Inject
@@ -252,7 +263,8 @@ class FailureTest(val target: Target) {
     fun fails_if_simple_cycle_is_detected() {
         assertThat {
             projectCompiler.source(
-                "MyComponent.kt", """
+                "MyComponent.kt",
+                """
                     import me.tatarka.inject.annotations.Component
                     import me.tatarka.inject.annotations.Inject
                     
@@ -273,7 +285,8 @@ class FailureTest(val target: Target) {
     fun includes_trace_when_cant_inject() {
         assertThat {
             projectCompiler.source(
-                "MyComponent.kt", """
+                "MyComponent.kt",
+                """
                     import me.tatarka.inject.annotations.Component
                     import me.tatarka.inject.annotations.Inject
                     
@@ -293,13 +306,14 @@ class FailureTest(val target: Target) {
     fun fails_if_parent_component_is_missing_val() {
         assertThat {
             projectCompiler.source(
-                "MyComponent.kt", """
+                "MyComponent.kt",
+                """
                import me.tatarka.inject.annotations.Component
                
                @Component abstract class ParentComponent()
                
                @Component abstract class MyComponent(@Component parent: ParentComponent)
-           """.trimIndent()
+                """.trimIndent()
             ).compile()
         }.isFailure().output().contains(
             "@Component parameter: parent must be val"
@@ -310,13 +324,14 @@ class FailureTest(val target: Target) {
     fun fails_if_parent_component_is_private() {
         assertThat {
             projectCompiler.source(
-                "MyComponent.kt", """
+                "MyComponent.kt",
+                """
                import me.tatarka.inject.annotations.Component
                
                @Component abstract class ParentComponent()
                
                @Component abstract class MyComponent(@Component private val parent: ParentComponent)
-           """.trimIndent()
+                """.trimIndent()
             ).compile()
         }.isFailure().output().contains(
             "@Component parameter: parent must not be private"
@@ -327,11 +342,12 @@ class FailureTest(val target: Target) {
     fun fails_if_companion_option_is_enabled_but_companion_is_missing() {
         assertThat {
             projectCompiler.source(
-                "MyComponent.kt", """
+                "MyComponent.kt",
+                """
                import me.tatarka.inject.annotations.Component
                 
                @Component abstract class MyComponent()
-            """.trimIndent()
+                """.trimIndent()
             ).options(Options(generateCompanionExtensions = true)).compile()
         }.isFailure().output().contains(
             "Missing companion for class: MyComponent"
@@ -340,6 +356,6 @@ class FailureTest(val target: Target) {
 }
 
 private fun Target.sourceExt() = when (this) {
-    Target.kapt -> "java"
-    Target.ksp -> "kt"
+    Target.KAPT -> "java"
+    Target.KSP -> "kt"
 }

--- a/compiler-tests/src/test/kotlin/me/tatarka/inject/test/Utils.kt
+++ b/compiler-tests/src/test/kotlin/me/tatarka/inject/test/Utils.kt
@@ -16,4 +16,3 @@ fun File.recursiveDelete() {
     }
     delete()
 }
-

--- a/integration-tests/common-companion/src/test/kotlin/me/tatarka/inject/test/CompanionTest.kt
+++ b/integration-tests/common-companion/src/test/kotlin/me/tatarka/inject/test/CompanionTest.kt
@@ -1,7 +1,6 @@
 package me.tatarka.inject.test
 
 import me.tatarka.inject.annotations.Component
-import me.tatarka.inject.test.create
 import kotlin.test.Test
 
 @Component abstract class CompanionComponent {

--- a/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/ComponentTest.kt
+++ b/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/ComponentTest.kt
@@ -9,7 +9,6 @@ import kotlin.test.Test
     abstract val foo: Foo
 }
 
-
 @Component abstract class Component2 {
     abstract val bar: Bar
 }

--- a/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/CycleErrorTest.kt
+++ b/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/CycleErrorTest.kt
@@ -5,6 +5,6 @@ import me.tatarka.inject.annotations.Inject
 @Inject class A(val b: B)
 @Inject class B(val a: A)
 
-//@Component abstract class MyComponent {
+// @Component abstract class MyComponent {
 //    abstract val a: A
-//}
+// }

--- a/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/DefaultArgTest.kt
+++ b/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/DefaultArgTest.kt
@@ -5,7 +5,11 @@ import assertk.assertions.isEqualTo
 import me.tatarka.inject.annotations.Component
 import kotlin.test.Test
 
-@Component abstract class DefaultArgComponent(val required1: String, val optional: String = "default", val required2: String)
+@Component abstract class DefaultArgComponent(
+    val required1: String,
+    val optional: String = "default",
+    val required2: String
+)
 
 class DefaultArgTest {
     @Test

--- a/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/FunctionTest.kt
+++ b/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/FunctionTest.kt
@@ -4,8 +4,8 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.isSameAs
-import me.tatarka.inject.annotations.Inject
 import me.tatarka.inject.annotations.Component
+import me.tatarka.inject.annotations.Inject
 import kotlin.test.Test
 
 @Inject class FunctionFoo

--- a/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/InjectFunctionTest.kt
+++ b/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/InjectFunctionTest.kt
@@ -30,7 +30,4 @@ class InjectFunctionTest {
 
         assertThat(component.bar()).isEqualTo("test")
     }
-
 }
-
-

--- a/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/Models.kt
+++ b/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/Models.kt
@@ -2,7 +2,9 @@ package me.tatarka.inject.test
 
 import me.tatarka.inject.annotations.Inject
 import me.tatarka.inject.annotations.Scope
-import kotlin.annotation.AnnotationTarget.*
+import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.annotation.AnnotationTarget.FUNCTION
+import kotlin.annotation.AnnotationTarget.PROPERTY_GETTER
 
 interface IFoo
 
@@ -22,9 +24,9 @@ var fooConstructorCount = 0
 
 @Inject data class Bar(val foo: Foo) : IFoo
 
-@Inject data class BarImpl(val foo: IFoo): IBar
+@Inject data class BarImpl(val foo: IFoo) : IBar
 
-@Inject class Baz: IFoo
+@Inject class Baz : IFoo
 
 class NamedFoo(val name: String)
 

--- a/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/MultibindsTest.kt
+++ b/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/MultibindsTest.kt
@@ -2,7 +2,10 @@ package me.tatarka.inject.test
 
 import assertk.assertThat
 import assertk.assertions.containsOnly
-import me.tatarka.inject.annotations.*
+import me.tatarka.inject.annotations.Component
+import me.tatarka.inject.annotations.IntoMap
+import me.tatarka.inject.annotations.IntoSet
+import me.tatarka.inject.annotations.Provides
 import kotlin.test.Test
 
 data class FooValue(val name: String)
@@ -25,7 +28,8 @@ data class FooValue(val name: String)
     fun fooValue1() = "1" to FooValue("1")
 
     val fooValue2
-        @Provides @IntoMap get() = "2" to FooValue("2") }
+        @Provides @IntoMap get() = "2" to FooValue("2")
+}
 
 @Component abstract class ParentSetComponent {
     val Foo.bind: IFoo

--- a/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/ProvidesTest.kt
+++ b/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/ProvidesTest.kt
@@ -1,7 +1,11 @@
 package me.tatarka.inject.test
 
 import assertk.assertThat
-import assertk.assertions.*
+import assertk.assertions.containsExactly
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isSameAs
+import assertk.assertions.isTrue
 import me.tatarka.inject.annotations.Component
 import me.tatarka.inject.annotations.Inject
 import me.tatarka.inject.annotations.Provides
@@ -266,4 +270,3 @@ class ProvidesTest {
         assertThat(component.fooFactory).isNotNull()
     }
 }
-

--- a/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/RecursiveTest.kt
+++ b/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/RecursiveTest.kt
@@ -24,7 +24,7 @@ abstract class CycleComponent {
     abstract val bar: CycleBar
 }
 
-//TODO: actually generate this
+// TODO: actually generate this
 class InjectCycleComponent : CycleComponent() {
     override val bar: CycleBar
         get() {
@@ -43,7 +43,7 @@ abstract class LazyCycleComponent {
     fun foo(bar: LazyCycleBar) = LazyCycleFoo(bar)
 }
 
-//TODO: actually generate this
+// TODO: actually generate this
 class InjectLazyCycleComponent : LazyCycleComponent() {
     override val bar: LazyCycleBar
         get() {
@@ -64,7 +64,7 @@ abstract class FunctionCycleComponent {
     fun foo(bar: FBar) = FFoo(bar)
 }
 
-//TODO: actually generate this
+// TODO: actually generate this
 class InjectFunctionCycleComponent : FunctionCycleComponent() {
     override val bar: FBar
         get() {
@@ -101,4 +101,3 @@ class RecursiveTest {
         assertThat(bar).isSameAs(bar.foo().bar)
     }
 }
-

--- a/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/ScopeTest.kt
+++ b/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/ScopeTest.kt
@@ -27,7 +27,6 @@ import kotlin.test.Test
         @Provides @CustomScope get() = this
 }
 
-
 @Component abstract class ParentScopedComponent(@Component val parent: CustomScopeConstructorComponent) {
     abstract val bar: CustomScopeBar
 }
@@ -48,9 +47,9 @@ class ScopedFoo(val bar: ScopedBar)
 
 @CustomScope
 @Inject
-class ScopedBar()
+class ScopedBar
 
-@CustomScope @Component abstract class DependentCustomScopeComponent() {
+@CustomScope @Component abstract class DependentCustomScopeComponent {
     abstract val foo: ScopedFoo
 
     abstract val bar: ScopedBar

--- a/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/SuspendTest.kt
+++ b/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/SuspendTest.kt
@@ -40,4 +40,3 @@ class SuspendTest {
         assertThat(component.suspendFoo()).isInstanceOf(Foo::class)
     }
 }
-

--- a/integration-tests/kapt/src/jmh/java/me/tatarka/inject/benchmark/ScopedAccessBenchmark.kt
+++ b/integration-tests/kapt/src/jmh/java/me/tatarka/inject/benchmark/ScopedAccessBenchmark.kt
@@ -13,7 +13,6 @@ abstract class ScopedAccessComponent {
     abstract val foo: Foo
 }
 
-
 class InjectLazyScopedAccessComponent : ScopedAccessComponent() {
     private val _foo by lazy {
         Foo()

--- a/kotlin-inject-compiler-core/src/main/kotlin/me/tatarka/inject/compiler/Ast.kt
+++ b/kotlin-inject-compiler-core/src/main/kotlin/me/tatarka/inject/compiler/Ast.kt
@@ -1,6 +1,10 @@
 package me.tatarka.inject.compiler
 
-import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.MemberName
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.TypeSpec
 import kotlin.reflect.KClass
 
 interface AstProvider {
@@ -29,7 +33,8 @@ interface Messenger {
 sealed class AstElement : AstAnnotated {
     inline fun <reified T : Annotation> hasAnnotation() = hasAnnotation(T::class.qualifiedName!!)
 
-    inline fun <reified T : Annotation> annotationAnnotatedWith(): AstAnnotation? = annotationAnnotatedWith(T::class.qualifiedName!!)
+    inline fun <reified T : Annotation> annotationAnnotatedWith(): AstAnnotation? =
+        annotationAnnotatedWith(T::class.qualifiedName!!)
 }
 
 interface AstAnnotated {

--- a/kotlin-inject-compiler-core/src/main/kotlin/me/tatarka/inject/compiler/CycleDetector.kt
+++ b/kotlin-inject-compiler-core/src/main/kotlin/me/tatarka/inject/compiler/CycleDetector.kt
@@ -8,7 +8,7 @@ class CycleDetector {
 
     fun check(element: AstElement): CycleResult {
         return if (element in _elements) {
-            //TODO: check resolvable
+            // TODO: check resolvable
             CycleResult.Cycle
         } else {
             _elements.add(element)

--- a/kotlin-inject-compiler-core/src/main/kotlin/me/tatarka/inject/compiler/TypeCollector.kt
+++ b/kotlin-inject-compiler-core/src/main/kotlin/me/tatarka/inject/compiler/TypeCollector.kt
@@ -39,6 +39,7 @@ class TypeCollector private constructor(private val provider: AstProvider, priva
     var providerMethods: List<AstMethod> = emptyList()
         private set
 
+    @Suppress("ComplexMethod")
     private fun collectTypes(
         astClass: AstClass,
         accessor: String? = null,
@@ -51,7 +52,7 @@ class TypeCollector private constructor(private val provider: AstProvider, priva
         for (method in typeInfo.providesMethods) {
             val scopeType = method.scopeType(options)
             if (scopeType != null && scopeType != typeInfo.elementScope) {
-                error("@Provides scope:${scopeType} must match component scope: ${typeInfo.elementScope}", method)
+                error("@Provides scope:$scopeType must match component scope: ${typeInfo.elementScope}", method)
             }
             val scopedComponent = if (scopeType != null) astClass else null
             if (method.hasAnnotation<IntoMap>()) {
@@ -59,7 +60,8 @@ class TypeCollector private constructor(private val provider: AstProvider, priva
                 val type = method.returnTypeFor(astClass)
                 if (type.packageName == "kotlin" && type.simpleName == "Pair") {
                     val typeArgs = method.returnTypeFor(astClass).arguments
-                    val mapType = TypeKey(declaredTypeOf(Map::class, typeArgs[0], typeArgs[1]), method.qualifier(options))
+                    val mapType =
+                        TypeKey(declaredTypeOf(Map::class, typeArgs[0], typeArgs[1]), method.qualifier(options))
                     addContainerType(mapType, mapOf, method, accessor, scopedComponent)
                 } else {
                     error("@IntoMap must have return type of type Pair", method)
@@ -81,8 +83,8 @@ class TypeCollector private constructor(private val provider: AstProvider, priva
             if (typeInfo.isComponent) {
                 addProviderMethod(key, method, accessor)
             } else {
-                // If we aren't a component ourselves, allow obtaining types from providers as these may be contributed from the
-                // eventual implementation
+                // If we aren't a component ourselves, allow obtaining types from providers as these may be contributed
+                // from the eventual implementation
                 addMethod(key, method, accessor, scopedComponent = null)
             }
         }
@@ -103,6 +105,7 @@ class TypeCollector private constructor(private val provider: AstProvider, priva
         }
     }
 
+    @Suppress("ComplexMethod", "LongMethod", "LoopWithTooManyJumpStatements")
     private fun collectTypeInfo(astClass: AstClass): TypeInfo {
         return TYPE_INFO_CACHE.getOrPut(astClass) {
             val isComponent = astClass.isComponent()
@@ -275,6 +278,7 @@ sealed class TypeCreator(val source: AstElement) {
         TypeCreator(source)
 }
 
+@Suppress("EnumNaming")
 enum class ContainerCreator {
     mapOf, setOf
 }

--- a/kotlin-inject-compiler-core/src/main/kotlin/me/tatarka/inject/compiler/Util.kt
+++ b/kotlin-inject-compiler-core/src/main/kotlin/me/tatarka/inject/compiler/Util.kt
@@ -20,13 +20,14 @@ fun <T> Iterable<T>.eqvItr(other: Iterable<T>, eqv: (T, T) -> Boolean): Boolean 
 }
 
 fun <T : Any> T?.eqv(other: T?, eqv: (T, T) -> Boolean): Boolean =
-    (this == null && other == null) ||
-            (this != null && other != null && eqv(this, other))
+    this == null && other == null ||
+        this != null && other != null && eqv(this, other)
 
-class HashCollector() {
+class HashCollector {
     var hash: Int = 1
         private set
 
+    @Suppress("MagicNumber")
     fun hash(arg: Any?) {
         hash = 31 * hash + arg.hashCode()
     }

--- a/kotlin-inject-compiler-kapt/src/main/kotlin/me/tatarka/inject/compiler/kapt/BaseInjectCompiler.kt
+++ b/kotlin-inject-compiler-kapt/src/main/kotlin/me/tatarka/inject/compiler/kapt/BaseInjectCompiler.kt
@@ -1,18 +1,15 @@
 package me.tatarka.inject.compiler.kapt
 
 import me.tatarka.inject.compiler.Options
-import me.tatarka.inject.compiler.Profiler
 import javax.annotation.processing.AbstractProcessor
 import javax.annotation.processing.Filer
-import javax.annotation.processing.Messager
 import javax.annotation.processing.ProcessingEnvironment
 import javax.lang.model.SourceVersion
-import javax.lang.model.util.Elements
-import javax.lang.model.util.Types
 
 private const val OPTION_GENERATE_COMPANION_EXTENSIONS = "me.tatarka.inject.generateCompanionExtensions"
 
-abstract class BaseInjectCompiler() : AbstractProcessor(),
+abstract class BaseInjectCompiler :
+    AbstractProcessor(),
     ModelAstProvider {
 
     protected lateinit var options: Options

--- a/kotlin-inject-compiler-kapt/src/main/kotlin/me/tatarka/inject/compiler/kapt/InjectCompiler.kt
+++ b/kotlin-inject-compiler-kapt/src/main/kotlin/me/tatarka/inject/compiler/kapt/InjectCompiler.kt
@@ -1,7 +1,9 @@
 package me.tatarka.inject.compiler.kapt
 
 import me.tatarka.inject.annotations.Component
-import me.tatarka.inject.compiler.*
+import me.tatarka.inject.compiler.FailedToGenerateException
+import me.tatarka.inject.compiler.InjectGenerator
+import me.tatarka.inject.compiler.Profiler
 import javax.annotation.processing.RoundEnvironment
 import javax.lang.model.element.TypeElement
 
@@ -13,6 +15,7 @@ class InjectCompiler(private val profiler: Profiler? = null) : BaseInjectCompile
         annotationNames.add(Component::class.java.canonicalName)
     }
 
+    @Suppress("LoopWithTooManyJumpStatements")
     override fun process(elements: Set<TypeElement>, env: RoundEnvironment): Boolean {
         if (elements.isEmpty()) {
             return false

--- a/kotlin-inject-compiler-kapt/src/main/kotlin/me/tatarka/inject/compiler/kapt/Util.kt
+++ b/kotlin-inject-compiler-kapt/src/main/kotlin/me/tatarka/inject/compiler/kapt/Util.kt
@@ -7,7 +7,14 @@ import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.asTypeName
-import kotlinx.metadata.*
+import kotlinx.metadata.Flag
+import kotlinx.metadata.KmClass
+import kotlinx.metadata.KmClassifier
+import kotlinx.metadata.KmConstructor
+import kotlinx.metadata.KmFunction
+import kotlinx.metadata.KmProperty
+import kotlinx.metadata.KmType
+import kotlinx.metadata.KmValueParameter
 import kotlinx.metadata.jvm.JvmMethodSignature
 import kotlinx.metadata.jvm.KotlinClassHeader
 import kotlinx.metadata.jvm.KotlinClassMetadata
@@ -67,6 +74,7 @@ val ExecutableElement.simpleSig: String
     get() {
         val name = simpleName.toString()
 
+        @Suppress("ComplexMethod", "NestedBlockDepth")
         fun convert(type: TypeMirror, out: StringBuilder) {
             with(out) {
                 when (type.kind) {
@@ -206,7 +214,7 @@ fun KmType.asTypeName(): TypeName? {
     val isNullable = Flag.Type.IS_NULLABLE(flags)
     return if (isFunction()) {
         if (isSuspendFunction()) {
-            val returnType = arguments[arguments.size -2].type!!.arguments[0]
+            val returnType = arguments[arguments.size - 2].type!!.arguments[0]
             val parameters = arguments.dropLast(2)
             LambdaTypeName.get(
                 parameters = parameters.map { it.type!!.asTypeName()!! }.toTypedArray(),
@@ -238,8 +246,8 @@ fun KmType.isFunction(): Boolean {
 
 private fun KmType.isSuspendFunction(): Boolean {
     return isFunction() &&
-            arguments.size >= 2 &&
-            arguments[arguments.size - 2].type?.classifier?.name == "kotlin/coroutines/Continuation"
+        arguments.size >= 2 &&
+        arguments[arguments.size - 2].type?.classifier?.name == "kotlin/coroutines/Continuation"
 }
 
 fun AnnotationMirror.eqv(other: AnnotationMirror): Boolean {
@@ -269,10 +277,10 @@ fun KmType.eqv(other: KmType): Boolean {
         }
     }
     return classifier == other.classifier &&
-            arguments.eqvItr(other.arguments) { a, b ->
-                a.variance == b.variance &&
-                        a.type.eqv(b.type, KmType::eqv)
-            }
+        arguments.eqvItr(other.arguments) { a, b ->
+            a.variance == b.variance &&
+                a.type.eqv(b.type, KmType::eqv)
+        }
 }
 
 fun KmType.eqvHashCode(collector: HashCollector = HashCollector()): Int {

--- a/kotlin-inject-compiler-ksp/src/main/kotlin/me/tatarka/inject/compiler/ksp/InjectProcessor.kt
+++ b/kotlin-inject-compiler-ksp/src/main/kotlin/me/tatarka/inject/compiler/ksp/InjectProcessor.kt
@@ -1,16 +1,16 @@
 package me.tatarka.inject.compiler.ksp
 
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.squareup.kotlinpoet.FileSpec
 import me.tatarka.inject.annotations.Component
 import me.tatarka.inject.compiler.FailedToGenerateException
 import me.tatarka.inject.compiler.InjectGenerator
 import me.tatarka.inject.compiler.Options
 import me.tatarka.inject.compiler.Profiler
-import com.google.devtools.ksp.processing.CodeGenerator
-import com.google.devtools.ksp.processing.KSPLogger
-import com.google.devtools.ksp.processing.Resolver
-import com.google.devtools.ksp.processing.SymbolProcessor
-import com.google.devtools.ksp.symbol.KSClassDeclaration
 
 class InjectProcessor(private val profiler: Profiler? = null) : SymbolProcessor, KSAstProvider {
 
@@ -30,6 +30,7 @@ class InjectProcessor(private val profiler: Profiler? = null) : SymbolProcessor,
         this.logger = logger
     }
 
+    @Suppress("LoopWithTooManyJumpStatements")
     override fun process(resolver: Resolver) {
         this.resolver = resolver
 

--- a/kotlin-inject-runtime/src/main/kotlin/me/tatarka/inject/annotations/Annotations.kt
+++ b/kotlin-inject-runtime/src/main/kotlin/me/tatarka/inject/annotations/Annotations.kt
@@ -1,7 +1,12 @@
 package me.tatarka.inject.annotations
 
 import kotlin.annotation.AnnotationRetention.RUNTIME
-import kotlin.annotation.AnnotationTarget.*
+import kotlin.annotation.AnnotationTarget.ANNOTATION_CLASS
+import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.annotation.AnnotationTarget.CONSTRUCTOR
+import kotlin.annotation.AnnotationTarget.FUNCTION
+import kotlin.annotation.AnnotationTarget.PROPERTY_GETTER
+import kotlin.annotation.AnnotationTarget.VALUE_PARAMETER
 
 @Retention(RUNTIME)
 @Target(CLASS, FUNCTION, CONSTRUCTOR)
@@ -26,4 +31,3 @@ annotation class IntoSet
 @Retention(RUNTIME)
 @Target(FUNCTION, PROPERTY_GETTER)
 annotation class IntoMap
-

--- a/kotlin-inject-runtime/src/main/kotlin/me/tatarka/inject/internal/ScopedComponent.kt
+++ b/kotlin-inject-runtime/src/main/kotlin/me/tatarka/inject/internal/ScopedComponent.kt
@@ -2,6 +2,7 @@ package me.tatarka.inject.internal
 
 import java.util.concurrent.ConcurrentHashMap
 
+@Suppress("VariableNaming")
 interface ScopedComponent {
     val _scoped: LazyMap
 }


### PR DESCRIPTION
Fixes https://github.com/evant/kotlin-inject/issues/84.

The ktlint config is kept to the absolute minimum and the code is mostly reformatted with `ktlint -F`.

The detekt config is a slightly stricter version of the default config, customized for the balance between how many `@Suppress` annotations are required in the code and the desire to keep important checks in.

@evant is enabling CI runs for PRs an option for us? Not sure how much room the current CircleCI plan leaves us but it would be great to run the checks and the tests on every push.