### PR TITLE
Fixed not using the typealias for function return types

### DIFF
--- a/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/InjectFunctionTest.kt
+++ b/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/InjectFunctionTest.kt
@@ -1,11 +1,14 @@
 package me.tatarka.inject.test
 
 import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.extracting
 import assertk.assertions.isEqualTo
 import me.tatarka.inject.annotations.Component
 import me.tatarka.inject.annotations.Inject
 import me.tatarka.inject.test.module.externalFunction
 import org.junit.Test
+import kotlin.reflect.full.declaredMembers
 
 @Component
 abstract class FunctionInjectionComponent {
@@ -26,6 +29,24 @@ typealias bar = () -> String
 @Inject
 fun bar(foo: foo): String = foo("test")
 
+@Target(AnnotationTarget.TYPE, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class FunctionAnnotation
+
+typealias baz = @FunctionAnnotation () -> String
+
+@Inject
+@FunctionAnnotation
+@Suppress("FunctionOnlyReturningConstant")
+fun baz(): String {
+    return "test"
+}
+
+@Component
+abstract class FunctionAnnotationInjectComponent {
+    abstract val baz: baz
+}
+
 class InjectFunctionTest {
 
     @Test
@@ -34,5 +55,15 @@ class InjectFunctionTest {
 
         assertThat(component.bar()).isEqualTo("test")
         assertThat(component.externalFunction()).isEqualTo("external")
+    }
+
+    @Test
+    fun generates_a_component_that_provides_a_function_with_an_annotation() {
+        val component = FunctionAnnotationInjectComponent::class.create()
+        val member = component::class.declaredMembers.first { it.name == "baz" }
+        val annotations = member.returnType.annotations
+
+        assertThat(annotations).extracting { it.annotationClass }
+            .containsExactly(FunctionAnnotation::class)
     }
 }

--- a/kotlin-inject-compiler/ksp/src/main/kotlin/me/tatarka/inject/compiler/ksp/Util.kt
+++ b/kotlin-inject-compiler/ksp/src/main/kotlin/me/tatarka/inject/compiler/ksp/Util.kt
@@ -68,7 +68,7 @@ val KSDeclaration.shortName: String
 fun KSType.asTypeName(): TypeName {
     val isFunction = isFunctionType
     val isSuspending = isSuspendFunctionType
-    if (isFunction || isSuspending) {
+    if ((isFunction || isSuspending) && declaration !is KSTypeAlias) {
         val returnType = arguments.last()
         val parameters = arguments.dropLast(1)
         return LambdaTypeName.get(


### PR DESCRIPTION
This can lose annotations which may be important (ex: @Composeable)