### PR TITLE
Use generated parent provider methods in more cases

### DIFF
--- a/compiler-tests/src/test/kotlin/me/tatarka/inject/test/FailureTest.kt
+++ b/compiler-tests/src/test/kotlin/me/tatarka/inject/test/FailureTest.kt
@@ -423,6 +423,31 @@ class FailureTest(private val target: Target) {
             )
         }
     }
+
+    @Test
+    fun fails_if_provides_in_parent_component_is_protected() {
+        assertThat {
+            projectCompiler.source(
+                "MyComponent.kt",
+                """
+               import me.tatarka.inject.annotations.Component
+               import me.tatarka.inject.annotations.Provides
+
+               @Component abstract class MyParentComponent {
+                 @Provides protected fun providesFoo() = "foo"
+               }
+
+               @Component abstract class MyChildComponent(@Component val parent: MyParentComponent) {
+                 abstract val foo: String
+               }
+                """.trimIndent()
+            ).compile()
+        }.isFailure().output().all {
+            contains(
+                "@Provides method is not accessible"
+            )
+        }
+    }
 }
 
 private fun Target.sourceExt() = when (this) {

--- a/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/NestedComponentTest.kt
+++ b/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/NestedComponentTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.Test
     abstract val parentNamedFoo: NamedFoo
 
     @Provides
-    fun foo() = NamedFoo("parent")
+    protected fun foo() = NamedFoo("parent")
 
     val Foo.binds: IFoo
         @Provides get() = this

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResult.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResult.kt
@@ -36,7 +36,7 @@ sealed class TypeResult {
     class Provides(
         val className: String,
         val methodName: String,
-        val accessor: String? = null,
+        val accessor: String = "",
         val receiver: TypeResultRef? = null,
         val isProperty: Boolean = false,
         val parameters: List<TypeResultRef> = emptyList(),
@@ -53,7 +53,7 @@ sealed class TypeResult {
      */
     class Scoped(
         val key: String,
-        val accessor: String?,
+        val accessor: String,
         val result: TypeResultRef,
     ) : TypeResult() {
         override val children

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultResolver.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultResolver.kt
@@ -121,7 +121,7 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
 
     private fun Provides(
         context: Context,
-        accessor: String?,
+        accessor: String,
         method: AstMethod,
         key: TypeKey,
     ) = withCycleDetection(key, method) {
@@ -146,7 +146,7 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
 
     private fun Scoped(
         context: Context,
-        accessor: String?,
+        accessor: String,
         key: TypeKey,
     ) = TypeResult.Scoped(
         key = key.toString(),


### PR DESCRIPTION
This allow more cases where a parent's providers are encapsulated as the
relevent types can still be accessed using an exposed provider method.

ex:
```kotlin
@Component abstract class Parent {
  abstract val foo: Foo

  @Provides protected fun provideFoo() = Foo()
}

@Component abstract class Child(@Component val parent) {
  abstract val foo: Foo
}
```
now resolves.

It will also now report an error is only `provideFoo` exists and it's
not accessible.