### PR TITLE
Allow params to be skipped if they have a default value

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin-inject = "0.3.7-RC"
+kotlin-inject = "0.3.8-SNAPSHOT"
 kotlin = "1.6.0-RC"
 ksp = "1.6.0-RC-1.0.1-RC"
 kotlinpoet = "1.10.1"

--- a/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/DefaultParamTest.kt
+++ b/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/DefaultParamTest.kt
@@ -1,0 +1,65 @@
+package me.tatarka.inject.test
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import me.tatarka.inject.annotations.Component
+import me.tatarka.inject.annotations.Inject
+import me.tatarka.inject.annotations.Provides
+import kotlin.test.Test
+
+@Inject
+class FooWithDefault(override val name: String = "default") : IFooWithDefault
+
+interface IFooWithDefault {
+    val name: String
+}
+
+typealias fooWithDefaultFun = () -> IFooWithDefault
+
+@Inject
+fun fooWithDefaultFun(name: String = "default"): IFooWithDefault {
+    return FooWithDefault(name)
+}
+
+@Component
+abstract class UseDefaultComponent {
+    abstract val foo: FooWithDefault
+    abstract val iFoo: IFooWithDefault
+    abstract val fooFun: fooWithDefaultFun
+
+    @Provides
+    fun iFoo(name: String = "default"): IFooWithDefault = FooWithDefault(name)
+}
+
+@Component
+abstract class OverrideDefaultComponent {
+    abstract val foo: FooWithDefault
+    abstract val iFoo: IFooWithDefault
+    abstract val fooFun: fooWithDefaultFun
+
+    val name: String
+        @Provides get() = "override"
+
+    @Provides
+    fun iFoo(name: String = "default"): IFooWithDefault = FooWithDefault(name)
+}
+
+class DefaultParamTest {
+    @Test
+    fun generates_a_component_that_uses_a_default_value_for_a_param() {
+        val component = UseDefaultComponent::class.create()
+
+        assertThat(component.foo.name).isEqualTo("default")
+        assertThat(component.iFoo.name).isEqualTo("default")
+        assertThat(component.fooFun().name).isEqualTo("default")
+    }
+
+    @Test
+    fun generates_a_component_that_overrides_a_default_value_for_a_param() {
+        val component = OverrideDefaultComponent::class.create()
+
+        assertThat(component.foo.name).isEqualTo("override")
+        assertThat(component.iFoo.name).isEqualTo("override")
+        assertThat(component.fooFun().name).isEqualTo("override")
+    }
+}

--- a/kotlin-inject-compiler/test/src/test/kotlin/me/tatarka/inject/test/FailureTest.kt
+++ b/kotlin-inject-compiler/test/src/test/kotlin/me/tatarka/inject/test/FailureTest.kt
@@ -472,4 +472,36 @@ class FailureTest {
             )
         }
     }
+
+    @ParameterizedTest
+    @EnumSource(Target::class)
+    fun fails_if_type_is_missing_arg_even_if_used_as_default_value(target: Target) {
+        val projectCompiler = ProjectCompiler(target, workingDir)
+
+        assertThat {
+            projectCompiler.source(
+                "MyComponent.kt",
+                """
+               import me.tatarka.inject.annotations.Inject
+               import me.tatarka.inject.annotations.Component
+
+               @Component abstract class MyComponent {
+                abstract val foo: Foo
+               }
+
+               @Inject class Foo(bar: Bar = Bar(""))
+
+               @Inject class Bar(value: String)
+
+               @Component abstract class MyChildComponent(@Component val parent: MyParentComponent) {
+                 abstract val foo: String
+               }
+                """.trimIndent()
+            ).compile()
+        }.isFailure().output().all {
+            contains(
+                "Cannot find an @Inject constructor or provider for: String"
+            )
+        }
+    }
 }


### PR DESCRIPTION
If a param has a default value and it's type is not found in the graph,
it will be skipped instead of throwing an error.

Fixes #161