### PR TITLE
Move back to Kotlin 1.5.31

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin-inject = "0.3.8-SNAPSHOT"
-kotlin = "1.6.0-RC"
-ksp = "1.6.0-RC-1.0.1-RC"
+kotlin = "1.5.31"
+ksp = "1.5.31-1.0.1"
 kotlinpoet = "1.10.1"
 junit5 = "5.8.1"
 [libraries]


### PR DESCRIPTION
Google has released a [new build of ksp](https://github.com/google/ksp/releases/tag/1.5.31-1.0.1) with Kotlin 1.5.31 which makes it possible for projects to use kotlin-inject without needing to use an unstable version of Kotlin.