### PR TITLE
Fix conflicting declarations with scoped @Provides functions

### DIFF
--- a/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/ScopeTest.kt
+++ b/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/ScopeTest.kt
@@ -149,6 +149,37 @@ abstract class NestedExternalScopedComponent(@Component val parent: ExternalChil
     abstract val foo: IExternalFoo
 }
 
+class Parameterized<E, S>
+
+@CustomScope
+@Inject
+class ParameterizedFoo(
+  private val p1: Parameterized<List<Int>, List<String>>,
+  private val p2: Parameterized<List<String>, List<String>>,
+  private val bar: ParameterizedBar
+)
+
+@CustomScope
+@Inject
+class ParameterizedBar(
+  private val p1: Parameterized<List<Int>, List<String>>,
+  private val p2: Parameterized<List<String>, List<String>>
+)
+
+@CustomScope
+@Component
+abstract class MultipleSameTypedScopedProvidesComponent {
+  abstract val foo: ParameterizedFoo
+
+  @CustomScope
+  @Provides
+  protected fun parameterized1() = Parameterized<List<Int>, List<String>>()
+
+  @CustomScope
+  @Provides
+  protected fun parameterized2() = Parameterized<List<String>, List<String>>()
+}
+
 class ScopeTest {
     @BeforeTest
     fun setup() {
@@ -251,4 +282,11 @@ class ScopeTest {
 
         assertThat(component.foo).isSameAs(component.foo)
     }
+
+  @Test
+  fun generates_a_component_when_multiple_scoped_provides_funs_have_the_same_return_type_with_different_type_args() {
+    val component = MultipleSameTypedScopedProvidesComponent::class.create()
+
+    assertThat(component.foo).isSameAs(component.foo)
+ }
 }

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/InjectGenerator.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/InjectGenerator.kt
@@ -221,7 +221,19 @@ fun AstClass.toInjectName(): String =
 
 fun AstType.toVariableName(): String =
     simpleName.split(".")
-        .joinToString("_") { it.decapitalize(Locale.US) }
+        .joinToString("_") { it.decapitalize(Locale.US) } +
+        joinArgumentTypeNames()
+
+private fun AstType.joinArgumentTypeNames(): String = when {
+  arguments.isEmpty() -> ""
+  else -> arguments.joinToString(separator = "") {
+    it
+      .simpleName
+      .split(".")
+      .joinToString("_") +
+      it.joinArgumentTypeNames()
+  }
+}
 
 private fun dumpGraph(astClass: AstClass, entries: List<TypeResult.Provider>): String {
     val out = StringBuilder(astClass.name).append("\n")


### PR DESCRIPTION
  - If multiple scoped @Provides functions have the same return type with different type args, the generated properties will have the same name
  - This causes conflicting declaration errors while compiling
  - To fix that, the type args are included in property name generation

Fixes #174 