### PR TITLE
Annotate a top-level property in LazyMap with @SharedImmutable

### DIFF
--- a/kotlin-inject-runtime/src/nativeMain/kotlin/me/tatarka/inject/internal/LazyMap.kt
+++ b/kotlin-inject-runtime/src/nativeMain/kotlin/me/tatarka/inject/internal/LazyMap.kt
@@ -1,8 +1,10 @@
 package me.tatarka.inject.internal
 
+import kotlin.native.concurrent.SharedImmutable
 import kotlinx.atomicfu.locks.ReentrantLock
 import kotlinx.atomicfu.locks.withLock
 
+@SharedImmutable
 private val NULL = Any()
 
 actual class LazyMap {


### PR DESCRIPTION
Kotlin/native otherwise crashes when `NULL` is accessed:

```
Uncaught Kotlin exception: kotlin.native.IncorrectDereferenceException: Trying to access top level value not marked as @ThreadLocal or @SharedImmutable from non-main thread
```

I actually ran into this error when I tried my components using `IsoState` as per your suggested in https://github.com/evant/kotlin-inject/issues/167#issuecomment-970449637.