### PR TITLE
Remove explicit retention annotations to get rid of kotlin js warnings

### DIFF
--- a/build-logic/src/main/kotlin/kotlin-inject.multiplatform.gradle.kts
+++ b/build-logic/src/main/kotlin/kotlin-inject.multiplatform.gradle.kts
@@ -19,12 +19,6 @@ kotlin {
     js(BOTH) {
         browser()
         nodejs()
-        // suppress noisy 'Reflection is not supported in JavaScript target'
-        for (compilation in arrayOf("main", "test")) {
-            compilations.getByName(compilation).kotlinOptions {
-                suppressWarnings = true
-            }
-        }
     }
 
     for (target in nativeTargets) {

--- a/kotlin-inject-runtime/src/commonMain/kotlin/me/tatarka/inject/annotations/Annotations.kt
+++ b/kotlin-inject-runtime/src/commonMain/kotlin/me/tatarka/inject/annotations/Annotations.kt
@@ -1,6 +1,5 @@
 package me.tatarka.inject.annotations
 
-import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.annotation.AnnotationTarget.ANNOTATION_CLASS
 import kotlin.annotation.AnnotationTarget.CLASS
 import kotlin.annotation.AnnotationTarget.CONSTRUCTOR
@@ -8,26 +7,20 @@ import kotlin.annotation.AnnotationTarget.FUNCTION
 import kotlin.annotation.AnnotationTarget.PROPERTY_GETTER
 import kotlin.annotation.AnnotationTarget.VALUE_PARAMETER
 
-@Retention(RUNTIME)
 @Target(CLASS, FUNCTION, CONSTRUCTOR)
 annotation class Inject
 
-@Retention(RUNTIME)
 @Target(CLASS, VALUE_PARAMETER)
 annotation class Component
 
-@Retention(RUNTIME)
 @Target(FUNCTION, PROPERTY_GETTER)
 annotation class Provides
 
-@Retention(RUNTIME)
 @Target(ANNOTATION_CLASS)
 annotation class Scope
 
-@Retention(RUNTIME)
 @Target(FUNCTION, PROPERTY_GETTER)
 annotation class IntoSet
 
-@Retention(RUNTIME)
 @Target(FUNCTION, PROPERTY_GETTER)
 annotation class IntoMap


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-41082.

Fixes #181