### PR TITLE
Bugfix/scope leak

### DIFF
--- a/ast/ksp/src/main/kotlin/me/tatarka/kotlin/ast/KSAst.kt
+++ b/ast/ksp/src/main/kotlin/me/tatarka/kotlin/ast/KSAst.kt
@@ -414,7 +414,13 @@ private class KSAstType private constructor(
     }
 
     override fun toString(): String {
-        return typeRef.toString().shortenPackage()
+        // rely on KotlinPoet's toString() as it includes type params
+        // we check for error first because KotlinPoet will throw an exception
+        return if (type.isError) {
+            typeRef.toString()
+        } else {
+            typeRef.toTypeName().toString()
+        }.shortenPackage()
     }
 
     override fun toTypeName(): TypeName {

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/Context.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/Context.kt
@@ -11,12 +11,14 @@ data class Context(
     val provider: AstProvider,
     val className: String,
     val types: TypeCollector.Result,
+    val scopeComponent: AstClass?,
     val scopeInterface: AstClass? = null,
     val args: List<Pair<AstType, String>> = emptyList(),
     val skipScoped: AstType? = null,
     val skipProvider: AstType? = null,
 ) {
-    fun withoutScoped(scoped: AstType) = copy(skipScoped = scoped)
+    fun withoutScoped(scoped: AstType, scopeComponent: AstClass) =
+        copy(skipScoped = scoped, scopeComponent = scopeComponent)
 
     fun withoutProvider(provider: AstType) = copy(skipProvider = provider)
 

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/InjectGenerator.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/InjectGenerator.kt
@@ -167,6 +167,7 @@ class InjectGenerator(
             provider = provider,
             className = injectName,
             types = types,
+            scopeComponent = elementScopeClass,
             scopeInterface = if (scopeFromParent) elementScopeClass else null,
         )
     }


### PR DESCRIPTION
One could leak a dependency by providing a scoped dependency from a
component with a shorter lifetime to one with a longer lifetime. We
detect this by ensuring the injected dependence's scope is always at
least as long as the dependency is it injected into. Unscoped
dependencies are always allowed as they don't have any particular
lifetime.

Fixes https://github.com/evant/kotlin-inject/issues/188