### PR TITLE
Fix printing of AstClass to print full type including outer class

### DIFF
--- a/ast/core/src/main/kotlin/me/tatarka/kotlin/ast/Ast.kt
+++ b/ast/core/src/main/kotlin/me/tatarka/kotlin/ast/Ast.kt
@@ -83,7 +83,7 @@ abstract class AstClass : AstElement(), AstAnnotated, AstHasModifiers {
     abstract override fun hashCode(): Int
 
     override fun toString(): String {
-        return if (packageName.isEmpty() || packageName == "kotlin") name else type.toString()
+        return type.toString()
     }
 
     abstract fun toClassName(): ClassName

--- a/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/InnerClassComponentTest.kt
+++ b/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/InnerClassComponentTest.kt
@@ -1,16 +1,25 @@
-package me.tatarka.inject.test
+// package is omitted to place this in the root to catch issues where inner class of the same name were not seen as
+// district. See https://github.com/evant/kotlin-inject/issues/192
 
+import assertk.assertThat
+import assertk.assertions.isNotNull
 import me.tatarka.inject.annotations.Component
+import me.tatarka.inject.test.Baz
+import me.tatarka.inject.test.Foo
 import kotlin.test.Test
 
 class Inner1 {
     @Component
-    abstract class InnerClassComponent
+    abstract class InnerClassComponent {
+        abstract val foo: Foo
+    }
 }
 
 class Inner2 {
     @Component
-    abstract class InnerClassComponent
+    abstract class InnerClassComponent {
+        abstract val baz: Baz
+    }
 }
 
 class InnerClassComponentTest {
@@ -18,5 +27,8 @@ class InnerClassComponentTest {
     fun generates_components_in_an_inner_class_with_a_unique_name() {
         val component1 = Inner1.InnerClassComponent::class.create()
         val component2 = Inner2.InnerClassComponent::class.create()
+
+        assertThat(component1.foo).isNotNull()
+        assertThat(component2.baz).isNotNull()
     }
 }

--- a/kotlin-inject-compiler/test/src/test/kotlin/me/tatarka/inject/test/FailureTest.kt
+++ b/kotlin-inject-compiler/test/src/test/kotlin/me/tatarka/inject/test/FailureTest.kt
@@ -151,6 +151,25 @@ class FailureTest {
 
     @ParameterizedTest
     @EnumSource(Target::class)
+    fun fails_if_inner_type_is_missing_inject(target: Target) {
+        val projectCompiler = ProjectCompiler(target, workingDir)
+        assertThat {
+            projectCompiler.source(
+                "MyComponent.kt",
+                """
+                import me.tatarka.inject.annotations.Component
+                class Foo { class Factory } 
+                @Component abstract class MyComponent {
+                    abstract fun provideFoo(): Foo.Factory
+                }
+                """.trimIndent()
+            ).compile()
+        }.isFailure().output()
+            .contains("Cannot find an @Inject constructor or provider for: Foo.Factory")
+    }
+
+    @ParameterizedTest
+    @EnumSource(Target::class)
     fun fails_if_type_cannot_be_provided_to_constructor(target: Target) {
         val projectCompiler = ProjectCompiler(target, workingDir)
         assertThat {


### PR DESCRIPTION
This makes it easier to find what class error messages are referring too
as well as fixes an incorrect cache hit when 2 inner classes in the root
package share a name.

Fixes #166, #192