### PR TITLE
Disallow depending on child deps from a parent component

### DIFF
--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/Context.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/Context.kt
@@ -23,4 +23,10 @@ data class Context(
     fun withoutProvider(provider: AstType) = copy(skipProvider = provider)
 
     fun withArgs(args: List<Pair<AstType, String>>) = copy(args = args)
+
+    fun withTypes(types: TypeCollector.Result) = if (this.types === types) {
+        this
+    } else {
+        copy(types = types)
+    }
 }


### PR DESCRIPTION
This is a stricter version of pr #201 for #188 that is easier to
understand. This matches dagger's behavior as well (when using
subcomponents a parent component can't depend on a subcomponent's
dependency).