### PR TITLE
Switch to manually defining artifact names

### DIFF
--- a/ast/kapt/build.gradle.kts
+++ b/ast/kapt/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":ast:core"))
+    implementation(project(":ast:ast-core"))
     implementation(libs.kotlinx.metadata.jvm)
     compileOnly(libs.jdk.compiler)
 }

--- a/ast/ksp/build.gradle.kts
+++ b/ast/ksp/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 dependencies {
-    api(project(":ast:core"))
+    api(project(":ast:ast-core"))
     api(libs.ksp)
     implementation(libs.kotlinpoet.ksp)
 }

--- a/build-logic/src/main/kotlin/kotlin-inject.publish.gradle.kts
+++ b/build-logic/src/main/kotlin/kotlin-inject.publish.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 version = rootProject.version
+group = rootProject.group
 
 fun MavenPublication.mavenCentralPom() {
     pom {
@@ -41,7 +42,6 @@ publishing {
         }
         publications.all {
             if (this is MavenPublication) {
-                groupId = rootProject.group.toString()
                 artifact(javadocJar)
                 mavenCentralPom()
             }
@@ -64,11 +64,6 @@ publishing {
             create<MavenPublication>("lib") {
                 from(components["java"])
                 mavenCentralPom()
-                groupId = rootProject.group.toString()
-                // We want the artifactId to represent the full project path
-                artifactId = path
-                    .trimStart(':')
-                    .replace(":", "-")
             }
         }
     }

--- a/integration-tests/kapt-companion/build.gradle.kts
+++ b/integration-tests/kapt-companion/build.gradle.kts
@@ -8,11 +8,11 @@ plugins {
 }
 
 dependencies {
-    kapt(project(":kotlin-inject-compiler:kapt"))
+    kapt(project(":kotlin-inject-compiler:kotlin-inject-compiler-kapt"))
     implementation(project(":kotlin-inject-runtime"))
     implementation(project(":integration-tests:module"))
 
-    kaptTest(project(":kotlin-inject-compiler:kapt"))
+    kaptTest(project(":kotlin-inject-compiler:kotlin-inject-compiler-kapt"))
     testImplementation(libs.kotlin.test)
     testImplementation(libs.javax.inject)
     testImplementation(libs.assertk)

--- a/integration-tests/kapt/build.gradle.kts
+++ b/integration-tests/kapt/build.gradle.kts
@@ -8,11 +8,11 @@ plugins {
 }
 
 dependencies {
-    kapt(project(":kotlin-inject-compiler:kapt"))
+    kapt(project(":kotlin-inject-compiler:kotlin-inject-compiler-kapt"))
     implementation(project(":kotlin-inject-runtime"))
     implementation(project(":integration-tests:module"))
 
-    kaptTest(project(":kotlin-inject-compiler:kapt"))
+    kaptTest(project(":kotlin-inject-compiler:kotlin-inject-compiler-kapt"))
     testImplementation(libs.kotlin.test)
     testImplementation(libs.kotlin.reflect)
     testImplementation(libs.kotlinx.coroutines)

--- a/integration-tests/ksp-companion/build.gradle.kts
+++ b/integration-tests/ksp-companion/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 dependencies {
-    ksp(project(":kotlin-inject-compiler:ksp"))
+    ksp(project(":kotlin-inject-compiler:kotlin-inject-compiler-ksp"))
 }
 
 kotlin {

--- a/integration-tests/ksp/build.gradle.kts
+++ b/integration-tests/ksp/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 dependencies {
-    ksp(project(":kotlin-inject-compiler:ksp"))
+    ksp(project(":kotlin-inject-compiler:kotlin-inject-compiler-ksp"))
 }
 
 kotlin {

--- a/integration-tests/module/build.gradle.kts
+++ b/integration-tests/module/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 dependencies {
-    add("kspMetadata", project(":kotlin-inject-compiler:ksp"))
+    add("kspMetadata", project(":kotlin-inject-compiler:kotlin-inject-compiler-ksp"))
 }
 
 kotlin {

--- a/kotlin-inject-compiler/core/build.gradle.kts
+++ b/kotlin-inject-compiler/core/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
     implementation(project(":kotlin-inject-runtime"))
-    api(project(":ast:core"))
+    api(project(":ast:ast-core"))
 
     testImplementation(libs.kotlin.test)
     testImplementation(libs.assertk)

--- a/kotlin-inject-compiler/kapt/build.gradle.kts
+++ b/kotlin-inject-compiler/kapt/build.gradle.kts
@@ -6,8 +6,8 @@ plugins {
 
 dependencies {
     implementation(project(":kotlin-inject-runtime"))
-    implementation(project(":kotlin-inject-compiler:core"))
-    implementation(project(":ast:kapt"))
+    implementation(project(":kotlin-inject-compiler:kotlin-inject-compiler-core"))
+    implementation(project(":ast:ast-kapt"))
     implementation(libs.kotlinx.metadata.jvm)
     compileOnly(libs.jdk.compiler)
 }

--- a/kotlin-inject-compiler/ksp/build.gradle.kts
+++ b/kotlin-inject-compiler/ksp/build.gradle.kts
@@ -8,8 +8,8 @@ plugins {
 
 dependencies {
     implementation(project(":kotlin-inject-runtime"))
-    implementation(project(":kotlin-inject-compiler:core"))
-    implementation(project(":ast:ksp"))
+    implementation(project(":kotlin-inject-compiler:kotlin-inject-compiler-core"))
+    implementation(project(":ast:ast-ksp"))
     implementation(libs.ksp)
     implementation(libs.kotlinpoet.ksp)
 }

--- a/kotlin-inject-compiler/test/build.gradle.kts
+++ b/kotlin-inject-compiler/test/build.gradle.kts
@@ -5,9 +5,9 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":kotlin-inject-compiler:core"))
-    implementation(project(":kotlin-inject-compiler:kapt"))
-    implementation(project(":kotlin-inject-compiler:ksp"))
+    implementation(project(":kotlin-inject-compiler:kotlin-inject-compiler-core"))
+    implementation(project(":kotlin-inject-compiler:kotlin-inject-compiler-kapt"))
+    implementation(project(":kotlin-inject-compiler:kotlin-inject-compiler-ksp"))
     implementation(libs.bundles.kotlin.compile.testing)
 
     testImplementation(libs.bundles.kotlin.test.junit5)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,12 +19,18 @@ rootProject.name = "kotlin-inject"
 
 include(":kotlin-inject-runtime")
 include(":kotlin-inject-compiler:core")
+project(":kotlin-inject-compiler:core").name = "kotlin-inject-compiler-core"
 include(":kotlin-inject-compiler:kapt")
+project(":kotlin-inject-compiler:kapt").name = "kotlin-inject-compiler-kapt"
 include(":kotlin-inject-compiler:ksp")
+project(":kotlin-inject-compiler:ksp").name = "kotlin-inject-compiler-ksp"
 include(":kotlin-inject-compiler:test")
 include(":ast:core")
+project(":ast:core").name = "ast-core"
 include(":ast:ksp")
+project(":ast:ksp").name = "ast-ksp"
 include(":ast:kapt")
+project(":ast:kapt").name = "ast-kapt"
 include(":integration-tests:kapt")
 include(":integration-tests:ksp")
 include(":integration-tests:module")


### PR DESCRIPTION
There seemd to be an inconsistenty in pulling group/artifact id's with
the way they were done previously. Instead we are simply setting the
gradle project names to match the artifact names and set the group to
the rootProject group.

Fixes #222