### PR TITLE
Make arg names not unique accross a component

### DIFF
--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/ArgNameAllocator.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/ArgNameAllocator.kt
@@ -1,0 +1,14 @@
+package me.tatarka.inject.compiler
+
+import com.squareup.kotlinpoet.NameAllocator
+
+internal class ArgNameAllocator {
+
+    private var nameAllocator = NameAllocator()
+
+    fun newName(index: Int): String = nameAllocator.newName(suggestion = "arg$index")
+
+    fun reset() {
+        nameAllocator = NameAllocator()
+    }
+}

--- a/kotlin-inject-compiler/core/src/test/kotlin/me/tatarka/inject/compiler/ArgNameAllocatorTest.kt
+++ b/kotlin-inject-compiler/core/src/test/kotlin/me/tatarka/inject/compiler/ArgNameAllocatorTest.kt
@@ -9,26 +9,22 @@ internal class ArgNameAllocatorTest {
     @Test
     fun `same indices lead to different arg names`() {
         val allocator = ArgNameAllocator()
-        allocator.assert(1, "arg1")
-        allocator.assert(1, "arg1_")
+        assertThat(allocator.newName(1)).isEqualTo("arg1")
+        assertThat(allocator.newName(1)).isEqualTo("arg1_")
     }
 
     @Test
     fun `reset leads to same arg names`() {
         val allocator = ArgNameAllocator()
-        allocator.assert(1, "arg1")
+        assertThat(allocator.newName(1)).isEqualTo("arg1")
         allocator.reset()
-        allocator.assert(1, "arg1")
+        assertThat(allocator.newName(1)).isEqualTo("arg1")
     }
 
     @Test
     fun `different indices lead to different arg names`() {
         val allocator = ArgNameAllocator()
-        allocator.assert(0, "arg0")
-        allocator.assert(1, "arg1")
-    }
-
-    private fun ArgNameAllocator.assert(index: Int, expected: String) {
-        assertThat(newName(index)).isEqualTo(expected)
+        assertThat(allocator.newName(0)).isEqualTo("arg0")
+        assertThat(allocator.newName(1)).isEqualTo("arg1")
     }
 }

--- a/kotlin-inject-compiler/core/src/test/kotlin/me/tatarka/inject/compiler/ArgNameAllocatorTest.kt
+++ b/kotlin-inject-compiler/core/src/test/kotlin/me/tatarka/inject/compiler/ArgNameAllocatorTest.kt
@@ -1,6 +1,7 @@
 package me.tatarka.inject.compiler
 
 import assertk.assertThat
+import assertk.assertions.isEqualTo
 import kotlin.test.Test
 
 internal class ArgNameAllocatorTest {
@@ -28,6 +29,6 @@ internal class ArgNameAllocatorTest {
     }
 
     private fun ArgNameAllocator.assert(index: Int, expected: String) {
-        assertThat(newName(index), "arg$expected")
+        assertThat(newName(index)).isEqualTo(expected)
     }
 }

--- a/kotlin-inject-compiler/core/src/test/kotlin/me/tatarka/inject/compiler/ArgNameAllocatorTest.kt
+++ b/kotlin-inject-compiler/core/src/test/kotlin/me/tatarka/inject/compiler/ArgNameAllocatorTest.kt
@@ -1,0 +1,33 @@
+package me.tatarka.inject.compiler
+
+import assertk.assertThat
+import kotlin.test.Test
+
+internal class ArgNameAllocatorTest {
+
+    @Test
+    fun `same indices lead to different arg names`() {
+        val allocator = ArgNameAllocator()
+        allocator.assert(1, "arg1")
+        allocator.assert(1, "arg1_")
+    }
+
+    @Test
+    fun `reset leads to same arg names`() {
+        val allocator = ArgNameAllocator()
+        allocator.assert(1, "arg1")
+        allocator.reset()
+        allocator.assert(1, "arg1")
+    }
+
+    @Test
+    fun `different indices lead to different arg names`() {
+        val allocator = ArgNameAllocator()
+        allocator.assert(0, "arg0")
+        allocator.assert(1, "arg1")
+    }
+
+    private fun ArgNameAllocator.assert(index: Int, expected: String) {
+        assertThat(newName(index), "arg$expected")
+    }
+}


### PR DESCRIPTION
This is a follow up of https://github.com/evant/kotlin-inject/pull/217

Create an ArgNameAllocator and reset it between provider calls. Else, the arg names would be unique across all functions of a component.