### PR TITLE
Add a test case for overwriting provides functions

### DIFF
--- a/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/InheritanceTest.kt
+++ b/integration-tests/common/src/test/kotlin/me/tatarka/inject/test/InheritanceTest.kt
@@ -13,6 +13,12 @@ interface ComponentInterface {
 }
 
 @Component
+abstract class InterfaceComponentWithIdenticalProvides(
+    @get:Provides
+    override val foo: Foo,
+) : ComponentInterface
+
+@Component
 abstract class InterfaceComponent : ComponentInterface
 
 interface GenericComponentInterface<T> {
@@ -48,6 +54,13 @@ class InheritanceTest {
     @Test
     fun generates_a_component_that_provides_a_dep_defined_in_an_implemented_interface() {
         val component = InterfaceComponent::class.create()
+
+        assertThat(component.foo).isNotNull()
+    }
+
+    @Test
+    fun test() {
+        val component = InterfaceComponentWithIdenticalProvides::class.create(Foo())
 
         assertThat(component.foo).isNotNull()
     }


### PR DESCRIPTION
This test case is currently failing. It currently leads to a stack overflow at runtime due to this code (example) being generated:
```kotlin
public class InjectInterfaceComponentWithIdenticalProvides(
  foo: Foo
) : InterfaceComponentWithIdenticalProvides(foo) {
  public override val foo: Foo
    get() = foo
}
```

The code that should be generated instead would be:

```kotlin
public class InjectInterfaceComponentWithIdenticalProvides(
  foo: Foo
) : InterfaceComponentWithIdenticalProvides(foo)
```