### PR TITLE
Don't provide assisted types beyond the original level where they are declared

### DIFF
--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/Context.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/Context.kt
@@ -26,6 +26,8 @@ data class Context(
 
     fun withArgs(args: List<Pair<AstType, String>>) = copy(args = args)
 
+    fun withoutArgs() = copy(args = emptyList())
+
     fun withTypes(types: TypeCollector.Result) = if (this.types === types) {
         this
     } else {

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultResolver.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultResolver.kt
@@ -95,7 +95,7 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
                     assistedFailed = true
                 }
             } else {
-                val result = resolveOrNull(context, element, key)
+                val result = resolveOrNull(context.withoutArgs(), element, key)
                 if (result != null) {
                     paramsWithName[param.name] = result
                 } else if (!param.hasDefault) {
@@ -147,7 +147,7 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
                     continue
                 }
             }
-            val result = resolveOrNull(context, element, key)
+            val result = resolveOrNull(context.withoutArgs(), element, key)
             if (result != null) {
                 paramsWithName[param.name] = result
             } else if (!param.hasDefault) {


### PR DESCRIPTION
Fixes #247