### PR TITLE
Fix android.md doc typos

### DIFF
--- a/docs/android.md
+++ b/docs/android.md
@@ -195,10 +195,10 @@ class HomeFragment(homeViewModel: (SavedStateHandle) -> HomeViewModel) : Fragmen
 kotlin-inject's [function injection](../README.md#function-injection) works quite nicely with compose.
 
 ```kotlin
-typealias Home = @Composeable () -> Unit
+typealias Home = @Composable () -> Unit
 
 @Inject
-@Composeable
+@Composable
 fun Home(repo: HomeRepository) {
      // ...
 }


### PR DESCRIPTION
Hi,
I've spotted a couple of typos on the Composable annotations while using the docs so here are the fixes.

Thanks a lot for the work you put into this library it's fantastic 😍 