### PR TITLE
Disallow scopes on types with assisted injection.

### DIFF
--- a/.static/detekt-config.yml
+++ b/.static/detekt-config.yml
@@ -145,6 +145,8 @@ style:
     active: true
   UseRequireNotNull:
     active: true
+  ThrowsCount:
+    active: false
 
 coroutines:
   active: true

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultResolver.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultResolver.kt
@@ -77,6 +77,14 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
         element: AstElement,
         params: List<AstParam>,
     ): Map<String, TypeResultRef> {
+        if (context.scopeComponent != null) {
+            val scopeType = context.scopeComponent.scopeType(options)
+            throw FailedToGenerateException(
+                "Cannot apply scope: @${scopeType!!.simpleName} to type with @Assisted parameters: [${
+                    params.filter { it.isAssisted() }.joinToString()
+                }]"
+            )
+        }
         val paramsWithName = LinkedHashMap<String, TypeResultRef>(context.args.size)
         var assistedFailed = false
         val args = context.args.toMutableList()
@@ -163,6 +171,14 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
                 """.trimIndent(),
                 element
             )
+            if (context.scopeComponent != null) {
+                val scopeType = context.scopeComponent.scopeType(options)
+                throw FailedToGenerateException(
+                    "Cannot apply scope: @${scopeType!!.simpleName} to type with assisted parameters: [${
+                        resolvedImplicitly.joinToString()
+                    }]"
+                )
+            }
         }
 
         return paramsWithName


### PR DESCRIPTION
These features don't really play well together because you'd expect the returned type to be always based on the assisted args.

Fixes #262