### PR TITLE
Add a warning for applying a scope on a generated component function or property as it will have no effect.

### DIFF
--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeCollector.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeCollector.kt
@@ -297,6 +297,14 @@ class TypeCollector(private val provider: AstProvider, private val options: Opti
                     }
                 }
                 if (method.isProvider()) {
+                    val scope = method.scopeType(options)
+                    if (scope != null) {
+                        provider.warn(
+                            "Scope: @${scope.simpleName} has no effect." +
+                                " Place on @Provides function or @Inject constructor instead.",
+                            method
+                        )
+                    }
                     providerMethods.add(method)
                 }
             }

--- a/kotlin-inject-compiler/test/src/test/kotlin/me/tatarka/inject/test/WarningTest.kt
+++ b/kotlin-inject-compiler/test/src/test/kotlin/me/tatarka/inject/test/WarningTest.kt
@@ -61,4 +61,40 @@ class WarningTest {
             contains("Annotate the following with @Assisted: [assisted: String]")
         }
     }
+
+    @ParameterizedTest
+    @EnumSource(Target::class)
+    fun warns_on_scope_on_provider_method_which_is_ignored(target: Target) {
+        val projectCompiler = ProjectCompiler(target, workingDir)
+
+        assertThat(
+            projectCompiler.source(
+                "MyComponent.kt",
+                """
+                import me.tatarka.inject.annotations.Component
+                import me.tatarka.inject.annotations.Scope
+                import me.tatarka.inject.annotations.Inject
+                import me.tatarka.inject.annotations.Provides
+                
+                @Scope annotation class MyScope1
+                @Scope annotation class MyScope2
+                
+                @MyScope1 @Component abstract class MyComponent1 {
+                    @get:MyScope1 abstract val foo: String
+                    
+                    @Provides fun str(): String = ""
+                }
+                
+                @MyScope2 @Component abstract class MyComponent2 {
+                    @MyScope2 abstract fun bar(): String
+                    
+                    @Provides fun str(): String = ""
+                }
+                """.trimIndent()
+            ).compile()
+        ).warnings().all {
+            contains("Scope: @MyScope1 has no effect. Place on @Provides function or @Inject constructor instead.")
+            contains("Scope: @MyScope2 has no effect. Place on @Provides function or @Inject constructor instead.")
+        }
+    }
 }


### PR DESCRIPTION
It should be placed on a @Provides function or @Inject constructor instead.

Note: due to the limitation with the KAPT back-end it will miss cases where the property is annotated itself instead of it's getter. ex: `@MyScope abstract val myProp` is missed but
`@get:MyScope abstract val myProp` is caught. This can be improved once the KAPT back-end is removed.

Partially addresses #238