### PR TITLE
Remove invalid token to fix CircleCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # kotlin-inject
 
-[![CircleCI](https://circleci.com/gh/evant/kotlin-inject.svg?style=svg)](https://circleci.com/gh/evant/kotlin-inject)[![Maven
-Central](https://img.shields.io/maven-central/v/me.tatarka.inject/kotlin-inject-runtime.svg)](https://search.maven.org/search?q=g:me.tatarka.inject)
+[![CircleCI](https://circleci.com/gh/evant/kotlin-inject.svg?style=svg)](https://circleci.com/gh/evant/kotlin-inject)
+[![Maven Central](https://img.shields.io/maven-central/v/me.tatarka.inject/kotlin-inject-runtime.svg)](https://search.maven.org/search?q=g:me.tatarka.inject)
 [![Sonatype Snapshot](https://img.shields.io/nexus/s/https/oss.sonatype.org/me.tatarka.inject/kotlin-inject-runtime.svg)](https://oss.sonatype.org/content/repositories/snapshots/me/tatarka/inject/)
 
 A compile-time dependency injection library for kotlin.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kotlin-inject
 
-[![CircleCI](https://circleci.com/gh/evant/kotlin-inject.svg?style=svg&circle-token=8792fa19911be92d6a1d66dd45ece3bf6712f778)](https://circleci.com/gh/evant/kotlin-inject)[![Maven
+[![CircleCI](https://circleci.com/gh/evant/kotlin-inject.svg?style=svg)](https://circleci.com/gh/evant/kotlin-inject)[![Maven
 Central](https://img.shields.io/maven-central/v/me.tatarka.inject/kotlin-inject-runtime.svg)](https://search.maven.org/search?q=g:me.tatarka.inject)
 [![Sonatype Snapshot](https://img.shields.io/nexus/s/https/oss.sonatype.org/me.tatarka.inject/kotlin-inject-runtime.svg)](https://oss.sonatype.org/content/repositories/snapshots/me/tatarka/inject/)
 


### PR DESCRIPTION
This was probably added when the project was private, but now that it is public and the token is no longer valid, we should remove it.

```bash
curl 'https://circleci.com/gh/evant/kotlin-inject.svg?style=svg&circle-token=8792fa19911be92d6a1d66dd45ece3bf6712f778'
```
`Invalid token provided.`