### PR TITLE
resolve scope type when comparing against constructor injection

### DIFF
--- a/integration-tests/common-test/src/test/kotlin/me/tatarka/inject/test/QualifierTest.kt
+++ b/integration-tests/common-test/src/test/kotlin/me/tatarka/inject/test/QualifierTest.kt
@@ -1,8 +1,11 @@
 package me.tatarka.inject.test
 
+import assertk.all
 import assertk.assertAll
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isNotSameInstanceAs
+import assertk.assertions.isSameInstanceAs
 import kotlin.test.Test
 
 class QualifierTest {
@@ -34,6 +37,22 @@ class QualifierTest {
         assertAll {
             assertThat(component.aliasedFoo.foo1.name).isEqualTo("1")
             assertThat(component.aliasedFoo.foo2.name).isEqualTo("2")
+        }
+    }
+
+    @Test
+    fun generates_a_component_that_constructs_different_scoped_constructor_values_based_on_the_type_alias_name() {
+        val component = ProvidesScopedConstructorAliasedComponent::class.create()
+
+        assertAll {
+            assertThat(component.foo1).all {
+                isSameInstanceAs(component.foo1)
+                isNotSameInstanceAs(component.foo2)
+            }
+            assertThat(component.foo2).all {
+                isSameInstanceAs(component.foo2)
+                isNotSameInstanceAs(component.foo1)
+            }
         }
     }
 }

--- a/integration-tests/common/src/main/kotlin/me/tatarka/inject/test/Qualifier.kt
+++ b/integration-tests/common/src/main/kotlin/me/tatarka/inject/test/Qualifier.kt
@@ -44,3 +44,14 @@ typealias AnnotatedAliasedFoo<T> = @FooAnnotation GenericFoo<T>
 
     @Provides fun foo2(): AnnotatedAliasedFoo<String> = GenericFoo("1")
 }
+
+typealias ScopedNamedFoo1 = ScopedFoo
+typealias ScopedNamedFoo2 = ScopedFoo
+
+typealias ScopedNamedBar1 = INamedBar
+typealias ScopedNamedBar2 = INamedBar
+
+@CustomScope @Component abstract class ProvidesScopedConstructorAliasedComponent {
+    abstract val foo1: ScopedNamedFoo1
+    abstract val foo2: ScopedNamedFoo2
+}

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultResolver.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultResolver.kt
@@ -366,7 +366,8 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
                 astClass,
             )
         }
-        return if (scopedResult != null && skipScoped != injectCtor.type) {
+        // constructor type is resolved from a typealias, need to resolve skipScoped too to ensure match
+        return if (scopedResult != null && skipScoped?.resolvedType() != injectCtor.type) {
             val (scopedComponent, types) = scopedResult
             Scoped(
                 context = withTypes(types),


### PR DESCRIPTION
constructor types are already resolved, since the scope type wasn't it was never matching and causing infinite recursion

Fixes #353