### PR TITLE
Linux Arm64

### DIFF
--- a/build-logic/src/main/kotlin/NativeTargets.kt
+++ b/build-logic/src/main/kotlin/NativeTargets.kt
@@ -1,7 +1,0 @@
-val nativeTargets = arrayOf(
-    "linuxX64",
-    "macosX64", "macosArm64",
-    "iosArm64", "iosX64", "iosSimulatorArm64",
-    "tvosArm64", "tvosX64", "tvosSimulatorArm64",
-    "watchosArm32", "watchosArm64", "watchosX64", "watchosSimulatorArm64",
-)

--- a/build-logic/src/main/kotlin/kotlin-inject.multiplatform.gradle.kts
+++ b/build-logic/src/main/kotlin/kotlin-inject.multiplatform.gradle.kts
@@ -17,6 +17,7 @@ kotlin {
         nodejs()
     }
 
+    linuxArm64()
     linuxX64()
     macosX64()
     macosArm64()


### PR DESCRIPTION
Add support for Linux Arm64, which is a tier 2 native target: https://kotlinlang.org/docs/native-target-support.html#tier-2