### PR TITLE
When comparing scope annotations, take their values into account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- `@Scope` annotations now take arguments into account. This means for example, if you have
+  ```kotlin
+  @Scope
+  annotation class NamedScope(val value: String)
+   ```
+  then the scope: `@NamedScope("one")` and `@NamedScope("two")` would be treated as distinct. Previously they were
+  treated as the same scope.
+
 ### Removed
 - The KAPT backend is removed, please migrate to KSP if you haven't already.
 

--- a/ast/ksp/src/main/kotlin/me/tatarka/kotlin/ast/KSAst.kt
+++ b/ast/ksp/src/main/kotlin/me/tatarka/kotlin/ast/KSAst.kt
@@ -556,8 +556,12 @@ private class KSAstAnnotation(private val resolver: Resolver, val annotation: KS
     }
 
     override fun toString(): String {
-        return "$annotation(${
-            annotation.arguments.joinToString(", ") { arg -> "${arg.name?.asString()}=${arg.value}" }
-        })"
+        return if (annotation.arguments.isEmpty()) {
+            annotation.toString()
+        } else {
+            "$annotation(${
+                annotation.arguments.joinToString(", ") { arg -> "${arg.name?.asString()}=${arg.value}" }
+            })"
+        }
     }
 }

--- a/integration-tests/common-test/src/test/kotlin/me/tatarka/inject/test/ScopeTest.kt
+++ b/integration-tests/common-test/src/test/kotlin/me/tatarka/inject/test/ScopeTest.kt
@@ -3,6 +3,7 @@ package me.tatarka.inject.test
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
+import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isSameInstanceAs
 import me.tatarka.inject.test.different.DifferentPackageScopedComponent
 import me.tatarka.inject.test.different.create
@@ -141,5 +142,15 @@ class ScopeTest {
 
         assertThat(component.holder.foo).isSameInstanceAs(component.holder.foo)
         assertThat(component.holder.foo2).isSameInstanceAs(component.holder.foo2)
+    }
+
+    @Test
+    fun generates_a_component_that_scopes_values_based_on_scope_arguments() {
+        val parent = ParentScopeWithArgComponent::class.create()
+        val child1 = ChildScopeWithArgComponent::class.create(parent)
+        val child2 = ChildScopeWithArgComponent::class.create(parent)
+
+        assertThat(child1.parentFoo).isSameInstanceAs(child2.parentFoo)
+        assertThat(child1.childFoo).isNotSameInstanceAs(child2.childFoo)
     }
 }

--- a/integration-tests/common/src/main/kotlin/me/tatarka/inject/test/Scope.kt
+++ b/integration-tests/common/src/main/kotlin/me/tatarka/inject/test/Scope.kt
@@ -236,3 +236,25 @@ abstract class SuperclassScopeFooComponent : BaseSuperclassScopeFooComponent {
 
     companion object
 }
+
+@Scope
+annotation class ScopeWithArg(val value: String)
+
+@Inject
+@ScopeWithArg("parent")
+class ScopedParentFoo
+
+@Inject
+@ScopeWithArg("child")
+class ScopedChildFoo
+
+@Component
+@ScopeWithArg("parent")
+abstract class ParentScopeWithArgComponent
+
+@Component
+@ScopeWithArg("child")
+abstract class ChildScopeWithArgComponent(@Component val parent: ParentScopeWithArgComponent) {
+    abstract val parentFoo: ScopedParentFoo
+    abstract val childFoo: ScopedChildFoo
+}

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/InjectGenerator.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/InjectGenerator.kt
@@ -48,7 +48,7 @@ class InjectGenerator(
     private val createGenerator = CreateGenerator(provider, options)
     private val typeCollector = TypeCollector(provider, options)
 
-    var scopeType: AstType? = null
+    var scope: AstAnnotation? = null
         private set
 
     fun generate(astClass: AstClass): FileSpec {
@@ -82,7 +82,7 @@ class InjectGenerator(
         val context = collectTypes(astClass, injectName)
         val resolver = TypeResultResolver(provider, options)
         val scope = context.types.scopeClass
-        scopeType = scope?.scopeType(options)
+        this.scope = scope?.scope(options)
 
         return with(provider) {
             TypeSpec.classBuilder(context.className)
@@ -192,18 +192,18 @@ class InjectGenerator(
     }
 }
 
-fun AstAnnotated.scopeType(options: Options): AstType? {
-    return scopeTypes(options).firstOrNull()
+fun AstAnnotated.scope(options: Options): AstAnnotation? {
+    return scopes(options).firstOrNull()
 }
 
-fun AstAnnotated.scopeTypes(options: Options): Sequence<AstType> {
+fun AstAnnotated.scopes(options: Options): Sequence<AstAnnotation> {
     val scopeAnnotations = annotationsAnnotatedWith(SCOPE.packageName, SCOPE.simpleName).map { annotation ->
-        annotation.type
+        annotation
     }
 
     if (options.enableJavaxAnnotations) {
         return annotationsAnnotatedWith(JAVAX_SCOPE.packageName, JAVAX_SCOPE.simpleName).map { annotation ->
-            annotation.type
+            annotation
         } + scopeAnnotations
     }
     return scopeAnnotations

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeCollector.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeCollector.kt
@@ -234,12 +234,13 @@ class TypeCollector(private val provider: AstProvider, private val options: Opti
             }
         }
 
-        private fun method(method: AstMember, accessor: Accessor, scope: AstAnnotation?, scopedComponent: AstClass?) = Method(
-            method = method,
-            accessor = accessor,
-            scope = scope,
-            scopedComponent = scopedComponent
-        )
+        private fun method(method: AstMember, accessor: Accessor, scope: AstAnnotation?, scopedComponent: AstClass?) =
+            Method(
+                method = method,
+                accessor = accessor,
+                scope = scope,
+                scopedComponent = scopedComponent
+            )
 
         private fun duplicate(key: TypeKey, newValue: AstElement, oldValue: AstElement) {
             provider.error("Cannot provide: $key", newValue)
@@ -309,6 +310,7 @@ class TypeCollector(private val provider: AstProvider, private val options: Opti
                         scopedMethodsWithScopedSuperMethod.remove(existing)
                         scopes.remove(existing)
                     }
+
                     existing != null -> {
                         // mark provides if it overrides one that's annotated
                         if (method.isProvides()) {
@@ -326,6 +328,7 @@ class TypeCollector(private val provider: AstProvider, private val options: Opti
                             }
                         }
                     }
+
                     else -> {
                         methods.add(method)
                         isProvides[method] = method.isProvides()

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeCollector.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeCollector.kt
@@ -387,7 +387,7 @@ class TypeCollector(private val provider: AstProvider, private val options: Opti
                 } else if (method.isProvider()) {
                     if (methodScopes != null) {
                         provider.warn(
-                            "Scope: @${methodScopes.first()} has no effect." +
+                            "Scope: ${methodScopes.first()} has no effect." +
                                 " Place on @Provides function or @Inject constructor instead.",
                             method
                         )

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResult.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResult.kt
@@ -1,6 +1,7 @@
 package me.tatarka.inject.compiler
 
 import com.squareup.kotlinpoet.MemberName
+import me.tatarka.kotlin.ast.AstAnnotation
 import me.tatarka.kotlin.ast.AstType
 
 /**
@@ -66,7 +67,7 @@ sealed class TypeResult {
      */
     class Constructor(
         val type: AstType,
-        val scope: AstType?,
+        val scope: AstAnnotation?,
         val outerClass: TypeResultRef?,
         val parameters: Map<String, TypeResultRef>,
         val supportsNamedArguments: Boolean,

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultResolver.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultResolver.kt
@@ -82,7 +82,7 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
     ): Map<String, TypeResultRef> {
         if (scope != null) {
             throw FailedToGenerateException(
-                "Cannot apply scope: @${scope} to type with @Assisted parameters: [${
+                "Cannot apply scope: $scope to type with @Assisted parameters: [${
                     params.filter { it.isAssisted() }.joinToString()
                 }]"
             )
@@ -176,7 +176,7 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
             )
             if (scope != null) {
                 throw FailedToGenerateException(
-                    "Cannot apply scope: @${scope} to type with @Assisted parameters: [${
+                    "Cannot apply scope: $scope to type with @Assisted parameters: [${
                         resolvedImplicitly.joinToString()
                     }]"
                 )
@@ -355,13 +355,13 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
                 buildString {
                     val scope = result.astClass.scope(options)
                     if (scope != null) {
-                        append("@$scope ")
+                        append("$scope ")
                     }
                     append(result.astClass)
                 }
             }
             throw FailedToGenerateException(
-                """Cannot find component with scope: @$scope to inject $astClass
+                """Cannot find component with scope: $scope to inject $astClass
                     |checked: [${checkedComponents.joinToString(", ")}]
                 """.trimMargin(),
                 astClass,
@@ -418,7 +418,7 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
     ): TypeResult {
         if (scope != null && method is AstFunction && method.isSuspend) {
             throw FailedToGenerateException(
-                "@Provides scoped with @${scope} cannot be suspend, consider returning Deferred<T> instead."
+                "@Provides scoped with $scope cannot be suspend, consider returning Deferred<T> instead."
             )
         }
         return withCycleDetection(key, method) {

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultResolver.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultResolver.kt
@@ -1,6 +1,7 @@
 package me.tatarka.inject.compiler
 
 import me.tatarka.inject.compiler.TypeResult.Object
+import me.tatarka.kotlin.ast.AstAnnotation
 import me.tatarka.kotlin.ast.AstClass
 import me.tatarka.kotlin.ast.AstConstructor
 import me.tatarka.kotlin.ast.AstElement
@@ -61,7 +62,7 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
     private fun resolveParams(
         context: Context,
         element: AstElement,
-        scope: AstType?,
+        scope: AstAnnotation?,
         params: List<AstParam>,
     ): Map<String, TypeResultRef> {
         return if (params.any { it.isAssisted() }) {
@@ -76,12 +77,12 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
     private fun resolveParamsNew(
         context: Context,
         element: AstElement,
-        scope: AstType?,
+        scope: AstAnnotation?,
         params: List<AstParam>,
     ): Map<String, TypeResultRef> {
         if (scope != null) {
             throw FailedToGenerateException(
-                "Cannot apply scope: @${scope.simpleName} to type with @Assisted parameters: [${
+                "Cannot apply scope: @${scope} to type with @Assisted parameters: [${
                     params.filter { it.isAssisted() }.joinToString()
                 }]"
             )
@@ -138,7 +139,7 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
     private fun resolveParamsLegacy(
         context: Context,
         element: AstElement,
-        scope: AstType?,
+        scope: AstAnnotation?,
         params: List<AstParam>,
     ): Map<String, TypeResultRef> {
         val size = params.size
@@ -175,7 +176,7 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
             )
             if (scope != null) {
                 throw FailedToGenerateException(
-                    "Cannot apply scope: @${scope.simpleName} to type with @Assisted parameters: [${
+                    "Cannot apply scope: @${scope} to type with @Assisted parameters: [${
                         resolvedImplicitly.joinToString()
                     }]"
                 )
@@ -347,12 +348,12 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
     }
 
     private fun Context.constructor(key: TypeKey, injectCtor: AstConstructor, astClass: AstClass): TypeResult {
-        val scope = astClass.scopeType(options)
+        val scope = astClass.scope(options)
         val scopedResult = if (scope != null) types.scopedAccessor(scope) else null
         if (scope != null && scopedResult == null) {
             val checkedComponents = types.iterator().asSequence().map { result ->
                 buildString {
-                    val scope = result.astClass.scopeType(options)
+                    val scope = result.astClass.scope(options)
                     if (scope != null) {
                         append("@$scope ")
                     }
@@ -412,12 +413,12 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
         context: Context,
         accessor: Accessor,
         method: AstMember,
-        scope: AstType?,
+        scope: AstAnnotation?,
         key: TypeKey,
     ): TypeResult {
         if (scope != null && method is AstFunction && method.isSuspend) {
             throw FailedToGenerateException(
-                "@Provides scoped with @${scope.simpleName} cannot be suspend, consider returning Deferred<T> instead."
+                "@Provides scoped with @${scope} cannot be suspend, consider returning Deferred<T> instead."
             )
         }
         return withCycleDetection(key, method) {
@@ -453,7 +454,7 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
         context: Context,
         constructor: AstConstructor,
         outerClassType: AstType?,
-        scope: AstType?,
+        scope: AstAnnotation?,
         key: TypeKey,
     ) = withCycleDetection(key, constructor) {
         TypeResult.Constructor(

--- a/kotlin-inject-compiler/test/src/test/kotlin/me/tatarka/inject/test/FailureTest.kt
+++ b/kotlin-inject-compiler/test/src/test/kotlin/me/tatarka/inject/test/FailureTest.kt
@@ -424,8 +424,8 @@ class FailureTest {
                 """.trimIndent()
             ).compile()
         }.output().all {
-            contains("Cannot apply scope: MyScope1")
-            contains("as scope: MyScope2 is already applied")
+            contains("Cannot apply scope: @MyScope1")
+            contains("as scope: @MyScope2 is already applied")
         }
     }
 
@@ -447,8 +447,8 @@ class FailureTest {
                 """.trimIndent()
             ).compile()
         }.output().all {
-            contains("Cannot apply scope: MyScope1")
-            contains("as scope: MyScope1 is already applied to parent")
+            contains("Cannot apply scope: @MyScope1")
+            contains("as scope: @MyScope1 is already applied to parent")
         }
     }
 
@@ -547,7 +547,7 @@ class FailureTest {
             ).compile()
         }.output().all {
             contains(
-                "@Provides with scope: MyScope cannot be provided in an unscoped component"
+                "@Provides with scope: @MyScope cannot be provided in an unscoped component"
             )
         }
     }
@@ -573,7 +573,7 @@ class FailureTest {
             ).compile()
         }.output().all {
             contains(
-                "@Provides with scope: MyScope2 must match component scope: MyScope1"
+                "@Provides with scope: @MyScope2 must match component scope: @MyScope1"
             )
         }
     }
@@ -907,8 +907,8 @@ class FailureTest {
                 """.trimIndent()
             ).compile()
         }.output().all {
-            contains("Cannot apply multiple scopes: [FooSingleton, FooSingleton2]")
-            contains("Cannot apply multiple scopes: [FooSingleton, FooSingleton3]")
+            contains("Cannot apply multiple scopes: [@FooSingleton, @FooSingleton2]")
+            contains("Cannot apply multiple scopes: [@FooSingleton, @FooSingleton3]")
         }
     }
 
@@ -966,11 +966,11 @@ class FailureTest {
                 """.trimIndent()
             ).compile()
         }.output().all {
-            contains("Cannot apply scope: FooSingleton2")
-            contains("as scope: FooSingleton is already applied")
+            contains("Cannot apply scope: @FooSingleton2")
+            contains("as scope: @FooSingleton is already applied")
 
-            contains("Cannot apply scope: FooSingleton")
-            contains("as scope: FooSingleton2 is already applied")
+            contains("Cannot apply scope: @FooSingleton")
+            contains("as scope: @FooSingleton2 is already applied")
         }
     }
 
@@ -1028,11 +1028,11 @@ class FailureTest {
                 """.trimIndent()
             ).compile()
         }.output().all {
-            contains("Cannot apply scope: FooSingleton2")
-            contains("as scope: FooSingleton is already applied")
+            contains("Cannot apply scope: @FooSingleton2")
+            contains("as scope: @FooSingleton is already applied")
 
-            contains("Cannot apply scope: FooSingleton")
-            contains("as scope: FooSingleton2 is already applied")
+            contains("Cannot apply scope: @FooSingleton")
+            contains("as scope: @FooSingleton2 is already applied")
         }
     }
 }


### PR DESCRIPTION
ex: @NamedScope("one") and @NamedScope("two") are now treated as distinct scopes.

Fixes #377