### PR TITLE
Use stable nodejs v22

### DIFF
--- a/build-logic/src/main/kotlin/kotlin-inject.multiplatform.gradle.kts
+++ b/build-logic/src/main/kotlin/kotlin-inject.multiplatform.gradle.kts
@@ -70,11 +70,6 @@ tasks.withType<KotlinNpmInstallTask> {
     args += "--ignore-scripts"
 }
 
-rootProject.the<NodeJsRootExtension>().apply {
-    nodeVersion = "22.0.0-nightly202404032241e8c5b3"
-    nodeDownloadBaseUrl = "https://nodejs.org/download/nightly"
-}
-
 rootProject.tasks.withType<KotlinNpmInstallTask>().configureEach {
     args.add("--ignore-engines")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin-inject = "0.7.0-SNAPSHOT"
-kotlin = "1.9.22"
-ksp = "1.9.22-1.0.17"
+kotlin = "1.9.24"
+ksp = "1.9.24-1.0.20"
 kotlinpoet = "1.16.0"
 junit5 = "5.9.3"
 detekt = "1.23.4"


### PR DESCRIPTION
  - The version still has to be specified until the Kotlin tooling updates