### PR TITLE
Allows annotating types with a qualifier

### DIFF
--- a/ast/core/src/main/kotlin/me/tatarka/kotlin/ast/Ast.kt
+++ b/ast/core/src/main/kotlin/me/tatarka/kotlin/ast/Ast.kt
@@ -197,7 +197,7 @@ private val DEFAULT_IMPORTS = arrayOf(
     "kotlin.text"
 )
 
-abstract class AstType : AstElement() {
+abstract class AstType : AstElement(), AstAnnotated {
 
     abstract val packageName: String
 

--- a/ast/ksp/src/main/kotlin/me/tatarka/kotlin/ast/KSAst.kt
+++ b/ast/ksp/src/main/kotlin/me/tatarka/kotlin/ast/KSAst.kt
@@ -532,6 +532,18 @@ private class KSAstType private constructor(
         }.shortenPackage()
     }
 
+    override fun hasAnnotation(packageName: String, simpleName: String): Boolean {
+        return typeRef.hasAnnotation(packageName, simpleName)
+    }
+
+    override fun annotation(packageName: String, simpleName: String): AstAnnotation? {
+        return typeRef.annotations(packageName, simpleName).firstOrNull()?.let { KSAstAnnotation(resolver, it) }
+    }
+
+    override fun annotationsAnnotatedWith(packageName: String, simpleName: String): Sequence<AstAnnotation> {
+        return typeRef.annotationsAnnotatedWith(packageName, simpleName).map { KSAstAnnotation(resolver, it) }
+    }
+
     override fun toTypeName(): TypeName {
         return typeRef.toTypeName()
     }

--- a/integration-tests/common-jvm/src/test/kotlin/me/tatarka/inject/test/JavaxAnnotationTest.kt
+++ b/integration-tests/common-jvm/src/test/kotlin/me/tatarka/inject/test/JavaxAnnotationTest.kt
@@ -23,7 +23,7 @@ abstract class JavaxComponent {
 }
 
 @Component
-abstract class NamedComponent {
+abstract class JavaxNamedComponent {
 
     @get:Named("one")
     abstract val one: String
@@ -40,7 +40,7 @@ abstract class NamedComponent {
 
 @Component
 @JavaxScope
-abstract class ScopedNamedComponent {
+abstract class JavaxScopedNamedComponent {
 
     @get:Named("one")
     abstract val one: String
@@ -68,7 +68,7 @@ class JavaxAnnotationTest {
 
     @Test
     fun generates_a_component_that_supports_the_named_qualifier() {
-        val component = NamedComponent::class.create()
+        val component = JavaxNamedComponent::class.create()
 
         assertThat(component.one).isEqualTo("one")
         assertThat(component.two).isEqualTo("two")
@@ -76,7 +76,7 @@ class JavaxAnnotationTest {
 
     @Test
     fun generates_a_scoped_component_that_supports_the_named_qualifier() {
-        val component = ScopedNamedComponent::class.create()
+        val component = JavaxScopedNamedComponent::class.create()
 
         assertThat(component.one).isEqualTo("one")
         assertThat(component.two).isEqualTo("two")

--- a/integration-tests/common-test/src/test/kotlin/me/tatarka/inject/test/QualifierTest.kt
+++ b/integration-tests/common-test/src/test/kotlin/me/tatarka/inject/test/QualifierTest.kt
@@ -62,6 +62,9 @@ class QualifierTest {
 
         assertThat(component.one).isEqualTo("one")
         assertThat(component.two).isEqualTo("two")
+        assertThat(component.three).isEqualTo("three")
+        assertThat(component.four).isEqualTo("four")
+        assertThat(component.five).isEqualTo("five")
     }
 
     @Test
@@ -70,5 +73,6 @@ class QualifierTest {
 
         assertThat(component.one).isEqualTo("one")
         assertThat(component.two).isEqualTo("two")
+        assertThat(component.three).isEqualTo("three")
     }
 }

--- a/integration-tests/common/src/main/kotlin/me/tatarka/inject/test/QualifierComponents.kt
+++ b/integration-tests/common/src/main/kotlin/me/tatarka/inject/test/QualifierComponents.kt
@@ -6,6 +6,12 @@ import me.tatarka.inject.annotations.Qualifier
 
 @Qualifier
 @Retention(AnnotationRetention.SOURCE)
+@Target(
+    AnnotationTarget.PROPERTY_GETTER,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.VALUE_PARAMETER,
+    AnnotationTarget.TYPE
+)
 annotation class Named(val value: String)
 
 @Component
@@ -17,11 +23,27 @@ abstract class NamedComponent {
     @get:Named("two")
     abstract val two: String
 
+    abstract val three: @Named("three") String
+
+    abstract val four: @Named("four") String
+
+    @get:Named("five")
+    abstract val five: String
+
     val provide1: String
         @Provides @Named("one") get() = "one"
 
     val provide2: String
         @Provides @Named("two") get() = "two"
+
+    val provide3: @Named("three") String
+        @Provides get() = "three"
+
+    val provide4: String
+        @Provides @Named("four") get() = "four"
+
+    val provide5: @Named("five") String
+        @Provides get() = "five"
 }
 
 @Component
@@ -34,6 +56,8 @@ abstract class ScopedNamedComponent {
     @get:Named("two")
     abstract val two: String
 
+    abstract val three: @Named("three") String
+
     @get:CustomScope
     val provide1: String
         @Provides @Named("one") get() = "one"
@@ -41,4 +65,9 @@ abstract class ScopedNamedComponent {
     @get:CustomScope
     val provide2: String
         @Provides @Named("two") get() = "two"
+
+    @get:CustomScope
+    val provide3: @Named("three") String
+        @Provides get() = "three"
 }
+

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeCollector.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeCollector.kt
@@ -388,7 +388,7 @@ class TypeCollector(private val provider: AstProvider, private val options: Opti
                         providesMembers.add(
                             TypeInfo.ProvidesMember(
                                 member,
-                                member.qualifier(provider, options),
+                                qualifier(provider, options, member, member.returnType),
                                 methodScope
                             )
                         )
@@ -404,7 +404,7 @@ class TypeCollector(private val provider: AstProvider, private val options: Opti
                     providerMembers.add(
                         TypeInfo.ProviderMember(
                             member,
-                            member.qualifier(provider, options)
+                            qualifier(provider, options, member, member.returnType),
                         )
                     )
                 }

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultResolver.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultResolver.kt
@@ -91,7 +91,9 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
         var assistedFailed = false
         val args = context.args.toMutableList()
         for (param in params) {
-            val key = TypeKey(param.type, param.qualifier(provider, options))
+            val type = param.type
+            val qualifier = qualifier(provider, options, param, type)
+            val key = TypeKey(type, qualifier)
             if (param.isAssisted()) {
                 val arg = args.removeFirstOrNull()
                 if (arg != null) {
@@ -148,7 +150,9 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
         val resolvedImplicitly = mutableListOf<AstParam>()
         for ((i, param) in params.withIndex()) {
             val indexFromEnd = size - i - 1
-            val key = TypeKey(param.type, param.qualifier(provider, options))
+            val type = param.type
+            val qualifier = qualifier(provider, options, param, type)
+            val key = TypeKey(type, qualifier)
             val arg = args.getOrNull(indexFromEnd)
             if (arg != null) {
                 val (type, name) = arg
@@ -475,7 +479,9 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
         return TypeResult.Container(
             creator = creator,
             args = args.map { (arg, types) ->
-                val key = TypeKey(arg.method.returnType, arg.method.qualifier(provider, options))
+                val returnType = arg.method.returnType
+                val qualifier = qualifier(provider, options, arg.method, returnType)
+                val key = TypeKey(returnType, qualifier)
                 TypeResultRef(key, mapArg(key, arg, types))
             }
         )


### PR DESCRIPTION
```
@Inject(@Qualifier("a") a: String)
```
and
```
@Inject(a: @Qualifier("a") String)
```
are equivalent.

For now, only annotating the outer type (no type args) is supported.

This lays the groundwork for allowing
```
typealias A = @Qualifier("a") String
```
to work in the future when typealias no longer work as a qualifier by itself.

Relates to #253