### PR TITLE
Update the generated filename for KmpComponentCreate functions

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,8 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <JetCodeStyleSettings>
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="ALLOW_TRAILING_COMMA" value="true" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/KmpComponentCreateGenerator.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/KmpComponentCreateGenerator.kt
@@ -18,7 +18,7 @@ class KmpComponentCreateGenerator(
     ) = with(provider) {
         FileSpec.builder(
             packageName = astFunction.packageName,
-            fileName = astFunction.filename(returnTypeClass),
+            fileName = "KmpComponentCreate${returnTypeClass.name}",
         ).apply {
             addFunction(
                 FunSpec
@@ -66,13 +66,5 @@ class KmpComponentCreateGenerator(
                     }.build(),
             )
         }.build()
-    }
-
-    private fun AstFunction.filename(returnTypeClass: AstClass) = buildString {
-        append("Target")
-        append(returnTypeClass.name)
-        receiverParameterType?.simpleName?.filter { it.isLetter() }?.let(::append)
-        append(name.replaceFirstChar(Char::uppercase))
-        append("Accessor")
     }
 }

--- a/kotlin-inject-compiler/ksp/src/main/kotlin/me/tatarka/inject/compiler/ksp/ProcessKmpComponentCreate.kt
+++ b/kotlin-inject-compiler/ksp/src/main/kotlin/me/tatarka/inject/compiler/ksp/ProcessKmpComponentCreate.kt
@@ -12,8 +12,7 @@ import me.tatarka.kotlin.ast.KSAstProvider
 internal fun processKmpComponentCreate(
     element: KSFunctionDeclaration,
     provider: KSAstProvider,
-    codeGenerator: CodeGenerator,
-    kmpComponentCreateGenerator: KmpComponentCreateGenerator,
+    kmpComponentCreateFunctionsByComponentType: MutableMap<AstClass, MutableList<AstFunction>>
 ): Boolean = with(provider) {
     val astFunction = element.toAstFunction()
     val returnType = astFunction.returnType
@@ -27,8 +26,20 @@ internal fun processKmpComponentCreate(
     val returnTypeClass = returnType.resolvedType().toAstClass()
     if (!astFunction.validateReturnType(returnTypeClass, provider)) return true
 
-    process(astFunction, returnTypeClass, codeGenerator, kmpComponentCreateGenerator)
+    kmpComponentCreateFunctionsByComponentType.getOrPut(returnTypeClass, ::ArrayList).add(astFunction)
+
     true
+}
+
+internal fun generateKmpComponentCreateFiles(
+    codeGenerator: CodeGenerator,
+    generator: KmpComponentCreateGenerator,
+    kmpComponentCreateFunctionsByComponentType: Map<AstClass, List<AstFunction>>
+) {
+    kmpComponentCreateFunctionsByComponentType.forEach { (componentType, kmpComponentCreateFunctions) ->
+        val file = generator.generate(componentType, kmpComponentCreateFunctions)
+        file.writeTo(codeGenerator, aggregating = false)
+    }
 }
 
 private fun AstFunction.validateIsExpect(provider: KSAstProvider) = isExpect.also { isValid ->
@@ -48,13 +59,3 @@ private fun AstFunction.validateReturnType(returnTypeClass: AstClass, provider: 
                 provider.error("$name's return type should be a type annotated with @Component", this)
             }
         }
-
-private fun process(
-    astFunction: AstFunction,
-    returnTypeClass: AstClass,
-    codeGenerator: CodeGenerator,
-    generator: KmpComponentCreateGenerator,
-) {
-    val file = generator.generate(astFunction, returnTypeClass)
-    file.writeTo(codeGenerator, aggregating = false)
-}

--- a/kotlin-inject-compiler/ksp/src/main/kotlin/me/tatarka/inject/compiler/ksp/ProcessKmpComponentCreate.kt
+++ b/kotlin-inject-compiler/ksp/src/main/kotlin/me/tatarka/inject/compiler/ksp/ProcessKmpComponentCreate.kt
@@ -38,7 +38,7 @@ internal fun generateKmpComponentCreateFiles(
 ) {
     kmpComponentCreateFunctionsByComponentType.forEach { (componentType, kmpComponentCreateFunctions) ->
         val file = generator.generate(componentType, kmpComponentCreateFunctions)
-        file.writeTo(codeGenerator, aggregating = false)
+        file.writeTo(codeGenerator, aggregating = true)
     }
 }
 


### PR DESCRIPTION
I missed the `Target...Accessor` part in the previous PR.

I also simplified the name, because what I had before was pretty gnarly since it was trying to avoid `FileAlreadyExistsException` in case there are multiple `@KmpComponentCreate` functions for the same `Component`.

With this new approach the following would cause a compile time error because the processor would generate two files named `KmpComponentCreateMyComponent.kt`:

```kotlin
@Component
abstract class MyComponent

@KmpComponentCreate
expect fun createKmp(): MyComponent

@KmpComponentCreate
expect fun MyComponent.Companion.createKmp(): MyComponent
```

Using the approach from before there would be no `FileAlreadyExistsException`, but the generated file names would be `KmpComponentCreateMyComponentCreateKmp.kt` and `KmpComponentCreateMyComponentMyComponentCompanionCreateKmp.kt` respectively. That works, and is safest, so the question is how ugly is too ugly for generated file names?

Another approach would be to defer writing the files until the final round, and then group the functions by `Component` type, and generate one file containing all of the functions for that `Component`.