### PR TITLE
fix generated code for scoped lazy circular dependency (#313)

### DIFF
--- a/integration-tests/common-test/src/test/kotlin/me/tatarka/inject/test/RecursiveTest.kt
+++ b/integration-tests/common-test/src/test/kotlin/me/tatarka/inject/test/RecursiveTest.kt
@@ -24,6 +24,14 @@ class RecursiveTest {
     }
 
     @Test
+    fun generates_a_component_that_provides_a_lazy_scoped_dea_recursively() {
+        val component: LazyScopedCycleComponent = LazyScopedCycleComponent::class.create()
+        val foo = component.foo
+
+        assertThat(foo).isSameInstanceAs(foo.lazy.value.foo.value)
+    }
+
+    @Test
     fun generates_a_component_that_provides_a_function_dea_recursively() {
         val component = FunctionCycleComponent::class.create()
         val bar = component.bar

--- a/integration-tests/common/src/main/kotlin/me/tatarka/inject/test/Recursive.kt
+++ b/integration-tests/common/src/main/kotlin/me/tatarka/inject/test/Recursive.kt
@@ -8,6 +8,25 @@ class LazyCycleFoo(val bar: LazyCycleBar)
 
 class LazyCycleBar(val foo: Lazy<LazyCycleFoo>)
 
+@CustomScope
+@Inject
+class LazyScopedCycleFoo(
+    val lazy: Lazy<LazyScopedCycleBar>,
+    val real: LazyScopedCycleBar,
+)
+
+@Inject
+class LazyScopedCycleBar(
+    val foo: Lazy<LazyScopedCycleFoo>
+)
+
+@CustomScope
+@Component
+abstract class LazyScopedCycleComponent {
+    abstract val foo: LazyScopedCycleFoo
+    abstract val bar: LazyScopedCycleBar
+}
+
 @Inject
 class FBar(val foo: () -> FFoo)
 

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultResolver.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultResolver.kt
@@ -558,7 +558,8 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
     private fun maybeLateInit(key: TypeKey, result: TypeResult): TypeResult {
         // TODO: better way to determine this?
         val validResultType =
-            result !is TypeResult.LocalVar && result !is TypeResult.Lazy && result !is TypeResult.Function
+            result !is TypeResult.LocalVar && result !is TypeResult.Lazy &&
+                result !is TypeResult.Function && result !is TypeResult.Scoped
         if (!validResultType) return result
         val name = cycleDetector.hitResolvable(key) ?: return result
         return LateInit(name, key, result)


### PR DESCRIPTION
* added test for case with scoped circular lazy dependency #313
* fix for the test case by not wrapping TypeResult.Scoped with TypeResult.LateInit because wrapping is already done for TypeResult.Scoped.result if it was needed

Fixes #313