### PR TITLE
Consider platform nullability non-null in params

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
   build-macos:
     macos:
       xcode: "14.1.0"
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
     <<: *defaults
     steps:
       - checkout

--- a/ast/core/src/main/kotlin/me/tatarka/kotlin/ast/Ast.kt
+++ b/ast/core/src/main/kotlin/me/tatarka/kotlin/ast/Ast.kt
@@ -235,6 +235,8 @@ abstract class AstType : AstElement(), AstAnnotated {
     }
 
     abstract fun toTypeName(): TypeName
+
+    abstract fun makeNonNullable(): AstType
 }
 
 abstract class AstAnnotation : AstElement() {

--- a/ast/ksp/src/main/kotlin/me/tatarka/kotlin/ast/KSAst.kt
+++ b/ast/ksp/src/main/kotlin/me/tatarka/kotlin/ast/KSAst.kt
@@ -547,6 +547,10 @@ private class KSAstType private constructor(
     override fun toTypeName(): TypeName {
         return typeRef.toTypeName()
     }
+
+    override fun makeNonNullable(): AstType {
+        return KSAstType(resolver, typeRef, type.makeNotNullable())
+    }
 }
 
 private class KSAstParam(

--- a/integration-tests/common-jvm/src/test/java/me/tatarka/inject/test/JavaFoo.java
+++ b/integration-tests/common-jvm/src/test/java/me/tatarka/inject/test/JavaFoo.java
@@ -4,14 +4,14 @@ import me.tatarka.inject.annotations.Inject;
 
 public class JavaFoo {
 
-    private final Foo foo;
+    private final IFoo foo;
 
     @Inject
-    public JavaFoo(Foo foo) {
+    public JavaFoo(IFoo foo) {
         this.foo = foo;
     }
 
-    public Foo getFoo() {
+    public IFoo getFoo() {
         return foo;
     }
 }

--- a/integration-tests/common-jvm/src/test/kotlin/me/tatarka/inject/test/JavaTest.kt
+++ b/integration-tests/common-jvm/src/test/kotlin/me/tatarka/inject/test/JavaTest.kt
@@ -4,11 +4,15 @@ import assertk.assertThat
 import assertk.assertions.isNotNull
 import me.tatarka.inject.annotations.Component
 import me.tatarka.inject.annotations.Inject
+import me.tatarka.inject.annotations.Provides
 import kotlin.test.Test
 
 @Component
 abstract class JavaInjectConstructorComponent {
     abstract val foo: JavaFoo
+
+    @Provides
+    fun Foo.bind(): IFoo = this
 
     abstract val foo2: JavaJavaXFoo
 }
@@ -22,6 +26,9 @@ class JavaJavaXBar(val foo: JavaJavaXFoo)
 @Component
 abstract class JavaProvidesComponent {
     abstract val bar: JavaBar
+
+    @Provides
+    fun Foo.bind(): IFoo = this
 
     abstract val bar2: JavaJavaXBar
 }

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultResolver.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultResolver.kt
@@ -91,7 +91,11 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
         var assistedFailed = false
         val args = context.args.toMutableList()
         for (param in params) {
-            val type = withPlatformNullabilityAsNotNull(param.type)
+            val type = if (param.type.isPlatform()) {
+                param.type.makeNonNullable()
+            } else {
+                param.type
+            }
             val qualifier = qualifier(provider, options, param, type)
             val key = TypeKey(type, qualifier)
             if (param.isAssisted()) {
@@ -150,7 +154,11 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
         val resolvedImplicitly = mutableListOf<AstParam>()
         for ((i, param) in params.withIndex()) {
             val indexFromEnd = size - i - 1
-            val type = withPlatformNullabilityAsNotNull(param.type)
+            val type = if (param.type.isPlatform()) {
+                param.type.makeNonNullable()
+            } else {
+                param.type
+            }
             val qualifier = qualifier(provider, options, param, type)
             val key = TypeKey(type, qualifier)
             val arg = args.getOrNull(indexFromEnd)
@@ -188,15 +196,6 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
         }
 
         return paramsWithName
-    }
-
-    /**
-     * Converts platform nullability to non-null. It's only viable for parameters in java code, never for provided types
-     */
-    private fun withPlatformNullabilityAsNotNull(type: AstType) = if (type.isPlatform()) {
-        type.makeNonNullable()
-    } else {
-        type
     }
 
     /**

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultResolver.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultResolver.kt
@@ -91,7 +91,7 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
         var assistedFailed = false
         val args = context.args.toMutableList()
         for (param in params) {
-            val type = param.type
+            val type = withPlatformNullabilityAsNotNull(param.type)
             val qualifier = qualifier(provider, options, param, type)
             val key = TypeKey(type, qualifier)
             if (param.isAssisted()) {
@@ -150,7 +150,7 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
         val resolvedImplicitly = mutableListOf<AstParam>()
         for ((i, param) in params.withIndex()) {
             val indexFromEnd = size - i - 1
-            val type = param.type
+            val type = withPlatformNullabilityAsNotNull(param.type)
             val qualifier = qualifier(provider, options, param, type)
             val key = TypeKey(type, qualifier)
             val arg = args.getOrNull(indexFromEnd)
@@ -188,6 +188,15 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
         }
 
         return paramsWithName
+    }
+
+    /**
+     * Converts platform nullability to non-null. It's only viable for parameters in java code, never for provided types
+     */
+    private fun withPlatformNullabilityAsNotNull(type: AstType) = if (type.isPlatform()) {
+        type.makeNonNullable()
+    } else {
+        type
     }
 
     /**


### PR DESCRIPTION
Allows injecting provided dependencies into java constructor even if parameter nullability is not specified in java

Fixes #401