### PR TITLE
Fix `NullPointerException` when resolving types

### DIFF
--- a/ast/core/src/main/kotlin/me/tatarka/kotlin/ast/Ast.kt
+++ b/ast/core/src/main/kotlin/me/tatarka/kotlin/ast/Ast.kt
@@ -203,6 +203,10 @@ abstract class AstType : AstElement(), AstAnnotated {
 
     abstract val simpleName: String
 
+    /**
+     * Returns a list of type arguments. This method may throw an [IllegalStateException] if the type
+     * cannot be resolved.
+     */
     abstract val arguments: List<AstType>
 
     abstract val isError: Boolean

--- a/ast/ksp/src/main/kotlin/me/tatarka/kotlin/ast/KSAst.kt
+++ b/ast/ksp/src/main/kotlin/me/tatarka/kotlin/ast/KSAst.kt
@@ -466,7 +466,10 @@ private class KSAstType private constructor(
 
     override val arguments: List<AstType>
         get() = type.arguments.map {
-            KSAstType(resolver, it.type!!)
+            val argumentType = checkNotNull(it.type) {
+                "Couldn't resolve type for $it with variance ${it.variance} from parent type $type"
+            }
+            KSAstType(resolver, argumentType)
         }
 
     override val isError: Boolean

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/InjectGenerator.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/InjectGenerator.kt
@@ -253,7 +253,16 @@ fun <E> qualifier(
 ): AstAnnotation? where E : AstElement, E : AstAnnotated {
     // check for qualifiers incorrectly applied to type arguments
     fun checkTypeArgs(packageName: String, simpleName: String, type: AstType) {
-        for (typeArg in type.arguments) {
+        @Suppress("SwallowedException")
+        val arguments = try {
+            type.arguments
+        } catch (e: IllegalStateException) {
+            // We do a deep analysis of all types, but not all types are necessarily resolvable, e.g.
+            // this may happen with star projections. In this case stop checking type arguments.
+            return
+        }
+
+        for (typeArg in arguments) {
             val argQualifier = typeArg.annotationAnnotatedWith(packageName, simpleName)
             if (argQualifier != null) {
                 provider.error("Qualifier: $argQualifier can only be applied to the outer type", typeArg)


### PR DESCRIPTION
KSP indicates that a type can for a type argument can be null, but kotlin-inject ignored that. This caused crashes in our case:
```
java.lang.NullPointerException
	at me.tatarka.kotlin.ast.KSAstType.getArguments(KSAst.kt:469)
	at me.tatarka.inject.compiler.InjectGeneratorKt.qualifier$checkTypeArgs(InjectGenerator.kt:256)
	at me.tatarka.inject.compiler.InjectGeneratorKt.qualifier$checkTypeArgs(InjectGenerator.kt:261)
	at me.tatarka.inject.compiler.InjectGeneratorKt.qualifier$checkTypeArgs(InjectGenerator.kt:261)
	at me.tatarka.inject.compiler.InjectGeneratorKt.qualifier$qualifier(InjectGenerator.kt:278)
	at me.tatarka.inject.compiler.InjectGeneratorKt.qualifier(InjectGenerator.kt:283)
	at me.tatarka.inject.compiler.TypeCollector.collectTypeInfo(TypeCollector.kt:391)
	at me.tatarka.inject.compiler.TypeCollector.collect(TypeCollector.kt:16)
	at me.tatarka.inject.compiler.TypeCollector.collect$default(TypeCollector.kt:15)
	at me.tatarka.inject.compiler.InjectGenerator.collectTypes(InjectGenerator.kt:177)
	at me.tatarka.inject.compiler.InjectGenerator.generateInjectComponent(InjectGenerator.kt:85)
	at me.tatarka.inject.compiler.InjectGenerator.generate(InjectGenerator.kt:68)
	at me.tatarka.inject.compiler.ksp.ProcessInjectKt.process(ProcessInject.kt:78)
	at me.tatarka.inject.compiler.ksp.ProcessInjectKt.processInject(ProcessInject.kt:28)
	at me.tatarka.inject.compiler.ksp.ProcessInjectKt.processInject$default(ProcessInject.kt:19)
	at me.tatarka.inject.compiler.ksp.InjectProcessor.process$lambda$0(InjectProcessor.kt:46)
	at kotlin.sequences.FilteringSequence$iterator$1.calcNext(Sequences.kt:171)
	at kotlin.sequences.FilteringSequence$iterator$1.hasNext(Sequences.kt:194)
	at kotlin.sequences.SequencesKt___SequencesKt.toList(_Sequences.kt:813)
	at me.tatarka.inject.compiler.ksp.InjectProcessor.process(InjectProcessor.kt:47)
```

I tried reproducing this issue, but I believe it has to do with certain types coming from pre-compiled artifacts. The crash occurred for us with:
```kotlin
Pair<KClass<out BaseModel>, () -> Renderer<*>>
```
Where for `Renderer<*>` the argument is resolved as star variance without any further type.