### PR TITLE
Assisted factory interface

### DIFF
--- a/ast/core/src/main/kotlin/me/tatarka/kotlin/ast/Ast.kt
+++ b/ast/core/src/main/kotlin/me/tatarka/kotlin/ast/Ast.kt
@@ -43,6 +43,8 @@ interface AstAnnotated {
     fun annotationsAnnotatedWith(packageName: String, simpleName: String): Sequence<AstAnnotation>
 }
 
+fun AstAnnotated.hasAnnotation(annotation: ClassName) = hasAnnotation(annotation.packageName, annotation.simpleName)
+
 fun AstAnnotated.annotationAnnotatedWith(packageName: String, simpleName: String): AstAnnotation? =
     annotationsAnnotatedWith(packageName, simpleName).firstOrNull()
 
@@ -247,6 +249,8 @@ abstract class AstAnnotation : AstElement() {
     abstract val type: AstType
 
     abstract fun toAnnotationSpec(): AnnotationSpec
+
+    abstract fun argument(name: String): Any?
 }
 
 abstract class AstParam : AstElement(), AstAnnotated {

--- a/ast/core/src/main/kotlin/me/tatarka/kotlin/ast/Ast.kt
+++ b/ast/core/src/main/kotlin/me/tatarka/kotlin/ast/Ast.kt
@@ -149,6 +149,8 @@ abstract class AstFunction : AstMember() {
 
     abstract val packageName: String
 
+    abstract val isTopLevel: Boolean
+
     abstract override fun equals(other: Any?): Boolean
 
     abstract override fun hashCode(): Int

--- a/ast/ksp/src/main/kotlin/me/tatarka/kotlin/ast/KSAst.kt
+++ b/ast/ksp/src/main/kotlin/me/tatarka/kotlin/ast/KSAst.kt
@@ -12,6 +12,7 @@ import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.FileLocation
+import com.google.devtools.ksp.symbol.FunctionKind
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSClassDeclaration
@@ -330,6 +331,9 @@ private class KSAstFunction(override val resolver: Resolver, override val declar
 
     override val packageName: String
         get() = declaration.packageName.asString()
+
+    override val isTopLevel: Boolean
+        get() = declaration.functionKind == FunctionKind.TOP_LEVEL
 
     override val receiverParameterType: AstType?
         get() = declaration.extensionReceiver?.let { KSAstType(resolver, it) }

--- a/ast/ksp/src/main/kotlin/me/tatarka/kotlin/ast/KSAst.kt
+++ b/ast/ksp/src/main/kotlin/me/tatarka/kotlin/ast/KSAst.kt
@@ -606,6 +606,9 @@ private class KSAstAnnotation(private val resolver: Resolver, val annotation: KS
         }
     }
 
+    override fun argument(name: String): Any? =
+        annotation.arguments.firstOrNull { it.name?.getShortName() == name }?.value
+
     override fun equals(other: Any?): Boolean {
         return other is KSAstAnnotation && annotation.eqv(other.annotation)
     }

--- a/integration-tests/common-test/src/test/kotlin/me/tatarka/inject/test/AssistedTest.kt
+++ b/integration-tests/common-test/src/test/kotlin/me/tatarka/inject/test/AssistedTest.kt
@@ -17,7 +17,7 @@ class AssistedTest {
 
     @Test
     fun generates_a_component_that_provides_an_assisted_function() {
-        val component = AssistedComponent::class.create()
+        val component:AssistedComponent = AssistedComponent::class.create()
 
         assertThat(component.barFactory("name").name).isEqualTo("name")
     }

--- a/integration-tests/common-test/src/test/kotlin/me/tatarka/inject/test/AssistedTest.kt
+++ b/integration-tests/common-test/src/test/kotlin/me/tatarka/inject/test/AssistedTest.kt
@@ -3,6 +3,7 @@ package me.tatarka.inject.test
 import assertk.all
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
 import assertk.assertions.isSameInstanceAs
 import assertk.assertions.prop
 import kotlin.test.Test
@@ -66,5 +67,22 @@ class AssistedTest {
             prop(AssistedAndUnrelatedDep::unrelatedDependency).prop(UnrelatedDependency::someString)
                 .isEqualTo("provided")
         }
+    }
+
+    @Test
+    fun generates_a_component_with_assisted_factory() {
+        val component: AssistedFactoryComponent = AssistedFactoryComponent::class.create()
+        val expectedName = "asd"
+        val expectedNum = 42
+        assertThat(component.barFactory.build(expectedNum, expectedName)).all {
+            prop(FactoryAssistedBar::name).isEqualTo(expectedName)
+            prop(FactoryAssistedBar::num).isEqualTo(expectedNum)
+        }
+    }
+
+    @Test
+    fun generates_a_component_that_injects_assisted_factory_in_constructor() {
+        val component: AssistedFactoryComponent = AssistedFactoryComponent::class.create()
+        assertThat(component.somethingDependant.factory.build(42, "asd")).isNotNull()
     }
 }

--- a/integration-tests/common-test/src/test/kotlin/me/tatarka/inject/test/InjectFunctionTest.kt
+++ b/integration-tests/common-test/src/test/kotlin/me/tatarka/inject/test/InjectFunctionTest.kt
@@ -19,7 +19,6 @@ class InjectFunctionTest {
 
         assertThat(component.barFactory()).isEqualTo("test")
         assertThat(component.externalFunctionFactory()).isEqualTo("external")
-        assertThat(component.objectFunctionFactory("42").name).isEqualTo("42")
     }
 
     @Test

--- a/integration-tests/common-test/src/test/kotlin/me/tatarka/inject/test/InjectFunctionTest.kt
+++ b/integration-tests/common-test/src/test/kotlin/me/tatarka/inject/test/InjectFunctionTest.kt
@@ -13,6 +13,14 @@ class InjectFunctionTest {
         assertThat(component.bar()).isEqualTo("test")
         assertThat(component.externalFunction()).isEqualTo("external")
     }
+    @Test
+    fun generates_a_component_that_provides_a_function_factory() {
+        val component: FunctionInjectionComponent = FunctionInjectionComponent::class.create()
+
+        assertThat(component.barFactory()).isEqualTo("test")
+        assertThat(component.externalFunctionFactory()).isEqualTo("external")
+        assertThat(component.objectFunctionFactory("42").name).isEqualTo("42")
+    }
 
     @Test
     fun generates_a_component_that_provides_a_function_with_receiver() {

--- a/integration-tests/common/src/main/kotlin/me/tatarka/inject/test/Assisted.kt
+++ b/integration-tests/common/src/main/kotlin/me/tatarka/inject/test/Assisted.kt
@@ -1,6 +1,7 @@
 package me.tatarka.inject.test
 
 import me.tatarka.inject.annotations.Assisted
+import me.tatarka.inject.annotations.AssistedFactory
 import me.tatarka.inject.annotations.Component
 import me.tatarka.inject.annotations.Inject
 import me.tatarka.inject.annotations.Provides
@@ -11,6 +12,23 @@ class AssistedBar(val foo: Foo, @Assisted val name: String)
 @Component
 abstract class AssistedComponent {
     abstract val barFactory: (name: String) -> AssistedBar
+}
+
+@Inject
+class FactoryAssistedBar(@Assisted val num: Int, val foo: Foo, @Assisted val name: String)
+
+@AssistedFactory
+interface AssistedBarFactory {
+    fun build(num: Int, name: String): FactoryAssistedBar
+}
+
+@Inject
+class SomethingDependantOnAssistedFactory(val factory: AssistedBarFactory)
+
+@Component
+abstract class AssistedFactoryComponent {
+    abstract val barFactory: AssistedBarFactory
+    abstract val somethingDependant: SomethingDependantOnAssistedFactory
 }
 
 @Inject

--- a/integration-tests/common/src/main/kotlin/me/tatarka/inject/test/Assisted.kt
+++ b/integration-tests/common/src/main/kotlin/me/tatarka/inject/test/Assisted.kt
@@ -14,8 +14,15 @@ abstract class AssistedComponent {
     abstract val barFactory: (name: String) -> AssistedBar
 }
 
+class SomethingProvided()
+
 @Inject
-class FactoryAssistedBar(@Assisted val num: Int, val foo: Foo, @Assisted val name: String)
+class FactoryAssistedBar(
+    @Assisted val num: Int,
+    val foo: Foo,
+    @Assisted val name: String,
+    val provided: SomethingProvided,
+)
 
 @AssistedFactory
 interface AssistedBarFactory {
@@ -29,6 +36,9 @@ class SomethingDependantOnAssistedFactory(val factory: AssistedBarFactory)
 abstract class AssistedFactoryComponent {
     abstract val barFactory: AssistedBarFactory
     abstract val somethingDependant: SomethingDependantOnAssistedFactory
+
+    @get:Provides
+    val name: SomethingProvided = SomethingProvided() // makes sure names don't clash with assisted params
 }
 
 @Inject

--- a/integration-tests/common/src/main/kotlin/me/tatarka/inject/test/InjectFunction.kt
+++ b/integration-tests/common/src/main/kotlin/me/tatarka/inject/test/InjectFunction.kt
@@ -17,19 +17,6 @@ abstract class FunctionInjectionComponent {
     abstract val barFactory: BarFactory
 
     abstract val externalFunctionFactory: ExternalFunctionFactory
-
-    abstract val objectFunctionFactory: ObjectFunctionFactory
-}
-
-@AssistedFactory("me.tatarka.inject.test.ObjectWithFunction.objectFunction")
-interface ObjectFunctionFactory {
-    operator fun invoke(name: String): SomethingNotInjectable
-}
-
-class SomethingNotInjectable(val name: String)
-
-object ObjectWithFunction {
-    fun objectFunction(@Assisted name: String): SomethingNotInjectable = SomethingNotInjectable(name)
 }
 
 @AssistedFactory("me.tatarka.inject.test.module.externalFunction")

--- a/integration-tests/common/src/main/kotlin/me/tatarka/inject/test/InjectFunction.kt
+++ b/integration-tests/common/src/main/kotlin/me/tatarka/inject/test/InjectFunction.kt
@@ -1,6 +1,7 @@
 package me.tatarka.inject.test
 
 import me.tatarka.inject.annotations.Assisted
+import me.tatarka.inject.annotations.AssistedFactory
 import me.tatarka.inject.annotations.Component
 import me.tatarka.inject.annotations.Inject
 import me.tatarka.inject.test.module.externalFunction
@@ -10,6 +11,22 @@ abstract class FunctionInjectionComponent {
     abstract val bar: bar
 
     abstract val externalFunction: externalFunction
+
+    abstract val fooFactory: FooFactory
+
+    abstract val barFactory: BarFactory
+
+    abstract val externalFunctionFactory: ExternalFunctionFactory
+}
+
+@AssistedFactory("me.tatarka.inject.test.module.externalFunction")
+interface ExternalFunctionFactory {
+    operator fun invoke(): String
+}
+
+@AssistedFactory("foo")
+interface FooFactory {
+    operator fun invoke(arg: F): String
 }
 
 typealias F = String
@@ -19,6 +36,11 @@ typealias foo = (F) -> String
 @Inject
 @Suppress("UNUSED_PARAMETER")
 fun foo(dep: Foo, @Assisted arg: F): String = arg
+
+@AssistedFactory("bar")
+interface BarFactory {
+    operator fun invoke(): String
+}
 
 typealias bar = () -> String
 

--- a/integration-tests/common/src/main/kotlin/me/tatarka/inject/test/InjectFunction.kt
+++ b/integration-tests/common/src/main/kotlin/me/tatarka/inject/test/InjectFunction.kt
@@ -17,6 +17,19 @@ abstract class FunctionInjectionComponent {
     abstract val barFactory: BarFactory
 
     abstract val externalFunctionFactory: ExternalFunctionFactory
+
+    abstract val objectFunctionFactory: ObjectFunctionFactory
+}
+
+@AssistedFactory("me.tatarka.inject.test.ObjectWithFunction.objectFunction")
+interface ObjectFunctionFactory {
+    operator fun invoke(name: String): SomethingNotInjectable
+}
+
+class SomethingNotInjectable(val name: String)
+
+object ObjectWithFunction {
+    fun objectFunction(@Assisted name: String): SomethingNotInjectable = SomethingNotInjectable(name)
 }
 
 @AssistedFactory("me.tatarka.inject.test.module.externalFunction")

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/InjectGenerator.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/InjectGenerator.kt
@@ -41,9 +41,6 @@ val JAVAX_SCOPE = ClassName("javax.inject", "Scope")
 val JAVAX_INJECT = ClassName("javax.inject", "Inject")
 val JAVAX_QUALIFIER = ClassName("javax.inject", "Qualifier")
 
-// TODO: implement the rest of assisted stuff
-val DAGGER_ASSISTED_FACTORY = ClassName("dagger.assisted", "AssistedFactory")
-
 val SCOPED_COMPONENT = ClassName("me.tatarka.inject.internal", "ScopedComponent")
 val LAZY_MAP = ClassName("me.tatarka.inject.internal", "LazyMap")
 
@@ -224,8 +221,7 @@ fun AstMember.isProvides() = hasAnnotation(PROVIDES)
 
 fun AstAnnotated.isInject() = hasAnnotation(INJECT)
 
-fun AstAnnotated.isAssistedFactory(options: Options) =
-    hasAnnotation(ASSISTED_FACTORY) || options.enableJavaxAnnotations && hasAnnotation(DAGGER_ASSISTED_FACTORY)
+fun AstAnnotated.isAssistedFactory() = hasAnnotation(ASSISTED_FACTORY)
 
 fun AstAnnotated.assistedFactoryFunctionName() =
     annotation(ASSISTED_FACTORY.packageName, ASSISTED_FACTORY.simpleName)

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/InjectGenerator.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/InjectGenerator.kt
@@ -254,6 +254,94 @@ fun AstClass.findInjectConstructors(messenger: Messenger, options: Options): Ast
     }
 }
 
+/**
+ * Finds a function to be generated for the assisted factory
+ * @throws FailedToGenerateException there are too many or none functions to generate
+ */
+fun findAssistedFactoryFunction(astClass: AstClass): AstFunction {
+    if (!astClass.isInterface) {
+        throw FailedToGenerateException("Assisted factory $astClass must be an interface.", astClass)
+    }
+    val abstractMethods = astClass.allMethods.filter { it.isAbstract }
+    if (abstractMethods.size > 1) {
+        throw FailedToGenerateException(
+            "Assisted factory $astClass has too many abstract functions: ${abstractMethods.map { it.name }}.",
+            astClass
+        )
+    }
+    val factoryFunction = abstractMethods.firstOrNull() as? AstFunction
+        ?: throw FailedToGenerateException("Assisted factory $astClass doesn't have any functions.", astClass)
+
+    if (factoryFunction.receiverParameterType != null) {
+        throw FailedToGenerateException(
+            "Assisted factory $astClass function ${factoryFunction.name} has a receiver parameter. " +
+                "Receiver parameters are not supported in assisted factory.",
+            astClass
+        )
+    }
+
+    return factoryFunction
+}
+
+/**
+ * Finds a function specified in injectFunction parameter of @AssistedFactory annotation
+ * @return null if function not specified
+ * @throws FailedToGenerateException if function is specified, but not found or doesn't match requirements
+ */
+fun findAssistedFactoryInjectFunction(
+    context: Context,
+    key: TypeKey,
+    astClass: AstClass,
+    factoryFunction: AstFunction,
+): AstFunction? {
+    val injectedFunctionName = astClass.assistedFactoryFunctionName()
+    if (injectedFunctionName.isNullOrBlank()) return null
+
+    val functionName = injectedFunctionName.substringAfterLast(".")
+    val functionPackage = injectedFunctionName.substringBeforeLast(".", key.type.packageName)
+    val functions = context.provider.findFunctions(functionPackage, functionName)
+        .toList()
+    val function = if (functions.isEmpty()) {
+        throw FailedToGenerateException("Inject function not found for Assisted factory $astClass.", astClass)
+    } else if (functions.size == 1) {
+        functions.first()
+    } else {
+        val injectFunctions = functions.filter { it.isInject() }
+        if (injectFunctions.isEmpty()) {
+            throw FailedToGenerateException(
+                "Inject function not found for Assisted factory $astClass.",
+                astClass
+            )
+        } else if (injectFunctions.size > 1) {
+            throw FailedToGenerateException(
+                "Too many candidates found for inject function for Assisted factory $astClass.",
+                astClass
+            )
+        } else {
+            injectFunctions.first()
+        }
+    }
+    if (function.receiverParameterType != null) {
+        throw FailedToGenerateException(
+            "Cannot inject function with receiver parameter in Assisted factory $astClass.",
+            astClass
+        )
+    }
+    if (function.returnType != factoryFunction.returnType) {
+        throw FailedToGenerateException(
+            "Return type of inject function doesn't match assisted factory's return type $astClass.",
+            astClass
+        )
+    }
+    if (!function.isTopLevel) {
+        throw FailedToGenerateException(
+            "Only top level functions can be injected in assisted factory: $astClass.",
+            astClass
+        )
+    }
+    return function
+}
+
 fun <E> qualifier(
     provider: AstProvider,
     options: Options,

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResult.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResult.kt
@@ -92,14 +92,14 @@ sealed class TypeResult {
     }
 
     class AssistedFactory(
-        val type: AstType,
+        val factoryType: AstType,
         val function: AstFunction,
         val result: TypeResultRef,
         val parameters: List<Pair<AstType, String>>,
     ) : TypeResult()
 
     class AssistedFunctionFactory(
-        val type: AstType,
+        val factoryType: AstType,
         val function: AstFunction,
         val parameters: List<Pair<AstType, String>>,
         val injectFunction: AstFunction,

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResult.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResult.kt
@@ -2,6 +2,7 @@ package me.tatarka.inject.compiler
 
 import com.squareup.kotlinpoet.MemberName
 import me.tatarka.kotlin.ast.AstAnnotation
+import me.tatarka.kotlin.ast.AstFunction
 import me.tatarka.kotlin.ast.AstType
 
 /**
@@ -89,6 +90,21 @@ sealed class TypeResult {
         override val children
             get() = args.iterator()
     }
+
+    class AssistedFactory(
+        val type: AstType,
+        val function: AstFunction,
+        val result: TypeResultRef,
+        val parameters: List<Pair<AstType, String>>,
+    ) : TypeResult()
+
+    class AssistedFunctionFactory(
+        val type: AstType,
+        val function: AstFunction,
+        val parameters: List<Pair<AstType, String>>,
+        val injectFunction: AstFunction,
+        val injectFunctionParameters: Map<String, TypeResultRef>
+    ) : TypeResult()
 
     /**
      * A lambda function that returns the type.

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultGenerator.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultGenerator.kt
@@ -61,6 +61,7 @@ data class TypeResultGenerator(val options: Options, val implicitAccessor: Acces
 
     private fun TypeResultRef.generate() = result.generate()
 
+    @Suppress("CyclomaticComplexMethod")
     private fun TypeResult.generate(): CodeBlock {
         return when (this) {
             is TypeResult.Provider -> generate()

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultGenerator.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultGenerator.kt
@@ -5,6 +5,8 @@ import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.LambdaTypeName
+import com.squareup.kotlinpoet.MemberName
+import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
@@ -73,6 +75,8 @@ data class TypeResultGenerator(val options: Options, val implicitAccessor: Acces
             is TypeResult.Lazy -> generate()
             is TypeResult.LateInit -> generate()
             is TypeResult.LocalVar -> generate()
+            is TypeResult.AssistedFactory -> generate()
+            is TypeResult.AssistedFunctionFactory -> generate()
         }
     }
 
@@ -253,6 +257,53 @@ data class TypeResultGenerator(val options: Options, val implicitAccessor: Acces
         }.build()
     }
 
+    private fun TypeResult.AssistedFactory.generate(): CodeBlock {
+        val typeSpec = TypeSpec.anonymousClassBuilder()
+            .addSuperinterface(type.toTypeName())
+            .addFunction(
+                FunSpec.builder(function.name)
+                    .addModifiers(KModifier.OVERRIDE)
+                    .apply {
+                        if (function.isSuspend) {
+                            addModifiers(KModifier.SUSPEND)
+                        }
+                    }
+                    .addAnnotations(function.annotations.map { it.toAnnotationSpec() }.asIterable())
+                    .addParameters(parameters.map { ParameterSpec.builder(it.second, it.first.toTypeName()).build() })
+                    .returns(result.key.type.toTypeName())
+                    .addCode(CodeBlock.of("return·%L", result.generate()))
+                    .build()
+            )
+            .build()
+        return CodeBlock.of("%L", typeSpec)
+    }
+
+    private fun TypeResult.AssistedFunctionFactory.generate(): CodeBlock {
+        val typeSpec = TypeSpec.anonymousClassBuilder()
+            .addSuperinterface(type.toTypeName())
+            .addFunction(
+                FunSpec.builder(function.name)
+                    .addModifiers(KModifier.OVERRIDE)
+                    .apply {
+                        if (function.isSuspend) {
+                            addModifiers(KModifier.SUSPEND)
+                        }
+                    }
+                    .addAnnotations(function.annotations.map { it.toAnnotationSpec() }.asIterable())
+                    .addParameters(parameters.map { ParameterSpec.builder(it.second, it.first.toTypeName()).build() })
+                    .returns(function.returnType.toTypeName())
+                    .addCode(
+                        CodeBlock.builder().apply {
+                            add("return·")
+                            addFunctionCall(injectFunction.toMemberName(), injectFunctionParameters)
+                        }.build()
+                    )
+                    .build()
+            )
+            .build()
+        return CodeBlock.of("%L", typeSpec)
+    }
+
     private fun TypeResult.Function.generate(): CodeBlock {
         return CodeBlock.builder().apply {
             // don't use beginControlFlow() so the arg list can be kept on the same line
@@ -288,25 +339,32 @@ data class TypeResultGenerator(val options: Options, val implicitAccessor: Acces
             }
             add("\n⇥")
 
-            add("%M(", name)
-            if (parameters.isNotEmpty()) {
-                add("\n⇥")
-            }
-            parameters.entries.forEachIndexed { i, (paramName, param) ->
-                if (i != 0) {
-                    add(",\n")
-                }
-                add("$paramName = ")
-                add(param.generate())
-            }
-            if (parameters.isNotEmpty()) {
-                add("\n⇤")
-            }
-            add(")")
+            addFunctionCall(name, parameters)
 
             // don't use endControlFlow() because it emits a newline after the closing brace
             add("\n⇤}")
         }.build()
+    }
+
+    private fun CodeBlock.Builder.addFunctionCall(
+        functionName: MemberName,
+        functionParameters: Map<String, TypeResultRef>,
+    ) {
+        add("%M(", functionName)
+        if (functionParameters.isNotEmpty()) {
+            add("\n⇥")
+        }
+        functionParameters.entries.forEachIndexed { i, (paramName, param) ->
+            if (i != 0) {
+                add(",\n")
+            }
+            add("$paramName = ")
+            add(param.generate())
+        }
+        if (functionParameters.isNotEmpty()) {
+            add("\n⇤")
+        }
+        add(")")
     }
 
     private fun TypeResult.Object.generate(): CodeBlock {

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultResolver.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultResolver.kt
@@ -366,7 +366,7 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
         val injectedFunctionName = astClass.assistedFactoryFunctionName()
         if (injectedFunctionName.isNullOrBlank()) {
             return TypeResult.AssistedFactory(
-                type = key.type,
+                factoryType = key.type,
                 function = factoryFunction,
                 parameters = namedArgs,
                 result = resolveOrNull(
@@ -420,7 +420,7 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
             }
 
             return TypeResult.AssistedFunctionFactory(
-                type = key.type,
+                factoryType = key.type,
                 function = factoryFunction,
                 parameters = namedArgs,
                 injectFunction = function,

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultResolver.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultResolver.kt
@@ -253,7 +253,7 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
             return Object(astClass.type)
         }
 
-        if (astClass.isAssistedFactory(options)) {
+        if (astClass.isAssistedFactory()) {
             return assistedFactory(astClass, key)
         }
 

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultResolver.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultResolver.kt
@@ -362,7 +362,6 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
             )
         }
 
-        // TODO: cleanup and extract a few functions
         val namedArgs = factoryFunction.parameters.map { param -> param.type to param.name }
         val injectedFunctionName = astClass.assistedFactoryFunctionName()
         if (injectedFunctionName.isNullOrBlank()) {
@@ -379,7 +378,6 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
         } else {
             val functionName = injectedFunctionName.substringAfterLast(".")
             val functionPackage = injectedFunctionName.substringBeforeLast(".", key.type.packageName)
-            // TODO: make sure found functions are global or static
             val functions = provider.findFunctions(functionPackage, functionName)
                 .toList()
             val function = if (functions.isEmpty()) {
@@ -411,6 +409,12 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
             if (function.returnType != factoryFunction.returnType) {
                 throw FailedToGenerateException(
                     "Return type of inject function doesn't match assisted factory's return type $astClass.",
+                    astClass
+                )
+            }
+            if (!function.isTopLevel) {
+                throw FailedToGenerateException(
+                    "Only top level functions can be injected in assisted factory: $astClass.",
                     astClass
                 )
             }

--- a/kotlin-inject-compiler/test/src/test/kotlin/me/tatarka/inject/test/FailureTest.kt
+++ b/kotlin-inject-compiler/test/src/test/kotlin/me/tatarka/inject/test/FailureTest.kt
@@ -1338,4 +1338,42 @@ class FailureTest {
             contains("e: [ksp] Cannot find an @Inject constructor or provider for: Foo")
         }
     }
+
+    @ParameterizedTest
+    @EnumSource(Target::class)
+    fun fails_if_trying_to_inject_class_function_to_assisted_factory(target: Target) {
+        val projectCompiler = ProjectCompiler(target, workingDir)
+
+        assertFailure {
+            projectCompiler.source(
+                "MyComponent.kt",
+                """
+                import me.tatarka.inject.annotations.Component
+                import me.tatarka.inject.annotations.Inject
+                import me.tatarka.inject.annotations.Provides
+                import me.tatarka.inject.annotations.Qualifier
+                import me.tatarka.inject.annotations.Assisted
+                import me.tatarka.inject.annotations.AssistedFactory
+                
+                class SomethingNotInjectable(val name: String)
+                
+                class ClassWithFunction {
+                    fun classFunction(@Assisted name: String): SomethingNotInjectable = SomethingNotInjectable(name)
+                }
+
+                @AssistedFactory("ClassWithFunction.classFunction")
+                interface ClassFunctionFactory {
+                    operator fun invoke(name: String): SomethingNotInjectable
+                }
+                
+                @Component
+                abstract class MultipleQualifiersComponent {
+                    abstract val classFunctionFactory: ClassFunctionFactory
+                }
+                """.trimIndent()
+            ).compile()
+        }.output().all {
+            contains("Only top level functions can be injected in assisted factory")
+        }
+    }
 }

--- a/kotlin-inject-runtime/src/commonMain/kotlin/me/tatarka/inject/annotations/Annotations.kt
+++ b/kotlin-inject-runtime/src/commonMain/kotlin/me/tatarka/inject/annotations/Annotations.kt
@@ -31,7 +31,7 @@ annotation class Assisted
 @Target(CLASS)
 annotation class AssistedFactory(
     /**
-     * Indicates that a global function should be called as an underlying factory.
+     * Indicates that a top level function should be called as an underlying factory.
      * If set it will behave similar to function injection.
      * Can be a function name if the function is in the same package or a full name with package otherwise.
      */

--- a/kotlin-inject-runtime/src/commonMain/kotlin/me/tatarka/inject/annotations/Annotations.kt
+++ b/kotlin-inject-runtime/src/commonMain/kotlin/me/tatarka/inject/annotations/Annotations.kt
@@ -28,5 +28,15 @@ annotation class IntoMap
 @Target(VALUE_PARAMETER)
 annotation class Assisted
 
+@Target(CLASS)
+annotation class AssistedFactory(
+    /**
+     * Indicates that a global function should be called as an underlying factory.
+     * If set it will behave similar to function injection.
+     * Can be a function name if the function is in the same package or a full name with package otherwise.
+     */
+    val injectFunction: String = ""
+)
+
 @Target(ANNOTATION_CLASS)
 annotation class Qualifier


### PR DESCRIPTION
- Added assisted factory interface support similar to dagger
- Regular interfaces are supported alongside with functional interfaces for easier migration from dagger
- Function injection is supported with optional parameter in `@AssistedFactory` annotation instead of name matching

Closes #243
Closes #252