### PR TITLE
Don't crash if the root of a trace is a TypeParameter

### DIFF
--- a/ast/ksp/src/main/kotlin/me/tatarka/kotlin/ast/KSAst.kt
+++ b/ast/ksp/src/main/kotlin/me/tatarka/kotlin/ast/KSAst.kt
@@ -531,10 +531,13 @@ private class KSAstType private constructor(
         // we check for error first because KotlinPoet will throw an exception
         return if (type.isError) {
             typeRef.toString()
-        } else if (type.declaration is KSTypeParameter) {
-            typeRef.toString()
         } else {
-            typeRef.toTypeName().toString()
+            try {
+                typeRef.toTypeName().toString()
+            }
+            catch (_: Throwable) {
+                typeRef.toString()
+            }
         }.shortenPackage()
     }
 

--- a/ast/ksp/src/main/kotlin/me/tatarka/kotlin/ast/KSAst.kt
+++ b/ast/ksp/src/main/kotlin/me/tatarka/kotlin/ast/KSAst.kt
@@ -21,7 +21,6 @@ import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeAlias
-import com.google.devtools.ksp.symbol.KSTypeParameter
 import com.google.devtools.ksp.symbol.KSTypeReference
 import com.google.devtools.ksp.symbol.KSValueParameter
 import com.google.devtools.ksp.symbol.Modifier
@@ -534,8 +533,7 @@ private class KSAstType private constructor(
         } else {
             try {
                 typeRef.toTypeName().toString()
-            }
-            catch (_: Throwable) {
+            } catch (_: Throwable) {
                 typeRef.toString()
             }
         }.shortenPackage()

--- a/ast/ksp/src/main/kotlin/me/tatarka/kotlin/ast/KSAst.kt
+++ b/ast/ksp/src/main/kotlin/me/tatarka/kotlin/ast/KSAst.kt
@@ -21,6 +21,7 @@ import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeAlias
+import com.google.devtools.ksp.symbol.KSTypeParameter
 import com.google.devtools.ksp.symbol.KSTypeReference
 import com.google.devtools.ksp.symbol.KSValueParameter
 import com.google.devtools.ksp.symbol.Modifier
@@ -529,6 +530,8 @@ private class KSAstType private constructor(
         // rely on KotlinPoet's toString() as it includes type params
         // we check for error first because KotlinPoet will throw an exception
         return if (type.isError) {
+            typeRef.toString()
+        } else if (type.declaration is KSTypeParameter) {
             typeRef.toString()
         } else {
             typeRef.toTypeName().toString()

--- a/kotlin-inject-compiler/test/src/test/kotlin/me/tatarka/inject/test/FailureTest.kt
+++ b/kotlin-inject-compiler/test/src/test/kotlin/me/tatarka/inject/test/FailureTest.kt
@@ -1293,6 +1293,7 @@ class FailureTest {
 
                 interface DestinationComponent<C> {
                   val c: C
+                  val cProvider: () -> C
                 }
 
                 @Inject class CType(val bar: Bar)


### PR DESCRIPTION
Fixes #426 

I'm not sure if this is the best solution, or why the type parameter is included in the CycleDetector. An alternate option is to catch this in the `CycleDetector` and just filter it out. Another option is to catch any exceptions from `toTypeName()` and use `typeRef.toString()` instead.