### PR TITLE
Skip validating companion & inner class types

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,6 +1,11 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <JetCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value />
+      </option>
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="ALLOW_TRAILING_COMMA" value="true" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/integration-tests/common-jvm/src/main/kotlin/me/tatarka/inject/test/SelfReference.kt
+++ b/integration-tests/common-jvm/src/main/kotlin/me/tatarka/inject/test/SelfReference.kt
@@ -1,0 +1,17 @@
+package me.tatarka.inject.test
+
+import me.tatarka.inject.annotations.Component
+
+@Component
+interface SelfReferenceCompanionComponent {
+    val foo: Foo
+
+    companion object : SelfReferenceCompanionComponent by SelfReferenceCompanionComponent::class.create()
+}
+
+@Component
+interface SelfReferenceInnerClassComponent {
+    val foo: Foo
+
+    class Instance : SelfReferenceInnerClassComponent by SelfReferenceInnerClassComponent::class.create()
+}

--- a/integration-tests/common-jvm/src/test/kotlin/me/tatarka/inject/test/SelfReferenceTest.kt
+++ b/integration-tests/common-jvm/src/test/kotlin/me/tatarka/inject/test/SelfReferenceTest.kt
@@ -1,0 +1,21 @@
+package me.tatarka.inject.test
+
+import assertk.assertThat
+import assertk.assertions.isNotNull
+import kotlin.test.Test
+
+class SelfReferenceTest {
+    @Test
+    fun creates_a_component_with_a_companion_that_references_itself() {
+        val component = SelfReferenceCompanionComponent
+
+        assertThat(component.foo).isNotNull()
+    }
+
+    @Test
+    fun creates_a_component_with_an_inner_class_that_references_itself() {
+        val component = SelfReferenceInnerClassComponent.Instance()
+
+        assertThat(component.foo).isNotNull()
+    }
+}

--- a/integration-tests/ksp/build.gradle.kts
+++ b/integration-tests/ksp/build.gradle.kts
@@ -38,11 +38,16 @@ kotlin {
         nativeTest {
             kotlin.srcDir("../common-native/src/test/kotlin")
         }
+        jvmMain {
+            kotlin.srcDir("../common-jvm/src/main/kotlin")
+            dependencies {
+                api(libs.javax.inject)
+            }
+        }
         jvmTest {
             kotlin.srcDir("../common-jvm/src/test/kotlin")
             dependencies {
                 implementation(libs.kotlin.reflect)
-                implementation(libs.javax.inject)
             }
         }
     }

--- a/kotlin-inject-compiler/ksp/src/main/kotlin/me/tatarka/inject/compiler/ksp/ProcessInject.kt
+++ b/kotlin-inject-compiler/ksp/src/main/kotlin/me/tatarka/inject/compiler/ksp/ProcessInject.kt
@@ -21,7 +21,7 @@ internal fun processInject(
     provider: KSAstProvider,
     codeGenerator: CodeGenerator,
     injectGenerator: InjectGenerator,
-    skipValidation: Boolean = false
+    skipValidation: Boolean = false,
 ): Boolean = with(provider) {
     val astClass = element.toAstClass()
     if (skipValidation || validate(element)) {
@@ -34,7 +34,7 @@ internal fun processInject(
 
 private fun validate(declaration: KSClassDeclaration): Boolean {
     return declaration.accept(
-        object : KSValidateVisitor({ node, _ ->
+        object : KSValidateVisitor({ node, data ->
             when (node) {
                 is KSFunctionDeclaration ->
                     node.getVisibility() != Visibility.PRIVATE &&
@@ -50,6 +50,8 @@ private fun validate(declaration: KSClassDeclaration): Boolean {
                                 ) ?: true
                             )
 
+                // skip validating inner classes/companion objects as they aren't scanned for types
+                is KSClassDeclaration -> node == data
                 else -> true
             }
         }) {
@@ -72,7 +74,7 @@ private fun process(
     astClass: AstClass,
     provider: KSAstProvider,
     codeGenerator: CodeGenerator,
-    generator: InjectGenerator
+    generator: InjectGenerator,
 ) {
     try {
         val file = generator.generate(astClass)


### PR DESCRIPTION
These aren't used for generation so it doesn't matter if they resolve. This also fixes an issue where a companion object implementing the component interface causes a stackoverflow.

Fixes #434