### PR TITLE
Use TypeKey to track scopes

### DIFF
--- a/integration-tests/common-test/src/test/kotlin/me/tatarka/inject/test/QualifierTest.kt
+++ b/integration-tests/common-test/src/test/kotlin/me/tatarka/inject/test/QualifierTest.kt
@@ -75,4 +75,12 @@ class QualifierTest {
         assertThat(component.two).isEqualTo("two")
         assertThat(component.three).isEqualTo("three")
     }
+
+    @Test
+    fun generates_a_component_that_constructs_different_scoped_values_based_on_a_qualifier_annotation2() {
+        val component = ScopedNamedComponent2::class.create()
+
+        assertThat(component.bar.one).isSameInstanceAs(component.bar.one)
+        assertThat(component.bar.two).isSameInstanceAs(component.bar.two)
+    }
 }

--- a/integration-tests/common/src/main/kotlin/me/tatarka/inject/test/QualifierComponents.kt
+++ b/integration-tests/common/src/main/kotlin/me/tatarka/inject/test/QualifierComponents.kt
@@ -1,6 +1,7 @@
 package me.tatarka.inject.test
 
 import me.tatarka.inject.annotations.Component
+import me.tatarka.inject.annotations.Inject
 import me.tatarka.inject.annotations.Provides
 import me.tatarka.inject.annotations.Qualifier
 
@@ -71,3 +72,34 @@ abstract class ScopedNamedComponent {
         @Provides get() = "three"
 }
 
+@Inject
+class ScopedNamedBar(
+    @Named("two")
+    val two: IFoo,
+
+    @Named("one")
+    val one: IFoo,
+)
+
+@Component
+@CustomScope
+abstract class ScopedNamedComponent2 {
+    abstract val bar: ScopedNamedBar
+
+    @CustomScope
+    @Provides
+    @Named("one")
+    fun provideFoo1(): IFoo {
+        return Foo()
+    }
+
+    @CustomScope
+    @Provides
+    @Named("two")
+    fun provideFoo2(
+        @Named("one")
+        foo: IFoo,
+    ): IFoo {
+        return Foo()
+    }
+}

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/Context.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/Context.kt
@@ -16,10 +16,10 @@ data class Context(
     val scopeInterface: AstClass?,
     val nameAllocator: NameAllocator,
     val args: List<Pair<AstType, String>> = emptyList(),
-    val skipScoped: AstType? = null,
+    val skipScoped: TypeKey? = null,
     val skipProvider: AstType? = null,
 ) {
-    fun withoutScoped(scoped: AstType, scopeComponent: AstClass) =
+    fun withoutScoped(scoped: TypeKey, scopeComponent: AstClass) =
         copy(skipScoped = scoped, scopeComponent = scopeComponent)
 
     fun withoutProvider(provider: AstType) = copy(skipProvider = provider)

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultResolver.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultResolver.kt
@@ -257,7 +257,7 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
     }
 
     private fun Context.method(key: TypeKey, creator: Member): TypeResult {
-        return if (creator.scopedComponent != null && skipScoped != creator.method.returnType) {
+        return if (creator.scopedComponent != null && skipScoped != key) {
             Scoped(
                 context = this,
                 accessor = creator.accessor,
@@ -379,8 +379,7 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
                 astClass,
             )
         }
-        // constructor type is resolved from a typealias, need to resolve skipScoped too to ensure match
-        return if (scopedResult != null && skipScoped?.resolvedType() != injectCtor.type) {
+        return if (scopedResult != null && skipScoped != key) {
             val (scopedComponent, types) = scopedResult
             Scoped(
                 context = withTypes(types),
@@ -460,7 +459,7 @@ class TypeResultResolver(private val provider: AstProvider, private val options:
     ) = TypeResult.Scoped(
         key = key,
         accessor = accessor,
-        result = resolve(context.withoutScoped(key.type, scopedComponent), element, key)
+        result = resolve(context.withoutScoped(key, scopedComponent), element, key)
     )
 
     private fun Constructor(


### PR DESCRIPTION
This ensures qualifiers are included in the comparision

Fixes #424