### PR TITLE
Don't generate parameter-less constructors

### DIFF
--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/InjectGenerator.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/InjectGenerator.kt
@@ -103,7 +103,7 @@ class InjectGenerator(
                         addSuperinterface(SCOPED_COMPONENT)
                     }
                     addModifiers(astClass.visibility.toKModifier())
-                    if (constructor != null) {
+                    if (constructor != null && constructor.parameters.isNotEmpty()) {
                         val funSpec = FunSpec.constructorBuilder()
                         val params = constructor.parameters
                         for (param in params) {


### PR DESCRIPTION
Minor style thing I noticed. Prior to this, constructors with no params would still always be generated when they could be omitted.