### PR TITLE
Align and share jvmTarget/JDK versions

### DIFF
--- a/build-logic/src/main/kotlin/kotlin-inject.detekt.gradle.kts
+++ b/build-logic/src/main/kotlin/kotlin-inject.detekt.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
 }
 
 tasks.withType<Detekt>().configureEach {
+    jvmTarget = libs.versions.jvmTarget.get()
     parallel = true
     buildUponDefaultConfig = true
     config.from(file(rootProject.projectDir.resolve(".static/detekt-config.yml")))

--- a/build-logic/src/main/kotlin/kotlin-inject.jvm.gradle.kts
+++ b/build-logic/src/main/kotlin/kotlin-inject.jvm.gradle.kts
@@ -7,11 +7,16 @@ plugins {
 
 val libs = the<LibrariesForLibs>()
 
-kotlin.compilerOptions.jvmTarget = JvmTarget.JVM_11
+kotlin.compilerOptions.jvmTarget = libs.versions.jvmTarget.map(JvmTarget::fromTarget)
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    toolchain {
+        languageVersion.set(libs.versions.jdk.map(JavaLanguageVersion::of))
+    }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.release.set(libs.versions.jvmTarget.map(String::toInt))
 }
 
 // Ensure xml test reports are generated

--- a/build-logic/src/main/kotlin/kotlin-inject.multiplatform.gradle.kts
+++ b/build-logic/src/main/kotlin/kotlin-inject.multiplatform.gradle.kts
@@ -1,8 +1,6 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithTests
 import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
-import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
-import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
 import org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,8 @@ kotlin = "2.0.0"
 ksp = "2.0.0-1.0.22"
 kotlinpoet = "1.16.0"
 junit5 = "5.9.3"
+jdk = "17"
+jvmTarget = "11"
 detekt = "1.23.6"
 [libraries]
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }


### PR DESCRIPTION
Was having issues running checks locally because Detekt by default uses the current JDK as the jvm target. This PR seeks to align all these via declaration in the version catalog as well as opportunistically modernize the java configuration too.