### PR TITLE
Upgrade KotlinPoet to the latest version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 kotlin-inject = "0.7.3-SNAPSHOT"
-kotlin = "2.0.0"
-ksp = "2.0.0-1.0.22"
-kotlinpoet = "1.16.0"
+kotlin = "2.0.10"
+ksp = "2.0.10-1.0.24"
+kotlinpoet = "2.0.0"
 junit5 = "5.9.3"
 jvmTarget = "11"
 detekt = "1.23.6"


### PR DESCRIPTION
Upgrade KotlinPoet to `2.0.0`, which comes with fixes for line wrapping. kotlin-inject ran into these edge cases for larger components where wrong line wrapping made the code not compile. The latest version of KotlinPoet fixes these issues.

KotlinPoet depends on Kotlin `2.0.10`, therefore upgrade Kotlin and KSP at the same time.