### PR TITLE
Fix #459: Suppress "Redundant visibility modifier" Warnings in Generated Code

### DIFF
--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/InjectGenerator.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/InjectGenerator.kt
@@ -72,6 +72,7 @@ class InjectGenerator(
         val createFunction = createGenerator.create(astClass, constructor, injectComponent, classOptIn)
 
         return FileSpec.builder(astClass.packageName, injectName).apply {
+            addAnnotation(createSuppressAnnotation("REDUNDANT_VISIBILITY_MODIFIER"))
             astClass.containingFile?.optInAnnotation()?.let { addAnnotation(it) }
             createFunction.forEach { addFunction(it) }
             addType(injectComponent)
@@ -424,6 +425,11 @@ fun AstType.toVariableName(): String =
 
 fun AstAnnotated.optInAnnotation(): AnnotationSpec? =
     annotation(OPT_IN.packageName, OPT_IN.simpleName)?.toAnnotationSpec()
+
+fun createSuppressAnnotation(reason: String): AnnotationSpec =
+    AnnotationSpec.builder(Suppress::class)
+        .addMember("%S", reason)
+        .build()
 
 private fun AstType.joinArgumentTypeNames(): String = when {
     arguments.isEmpty() -> ""

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/KmpComponentCreateGenerator.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/KmpComponentCreateGenerator.kt
@@ -20,6 +20,7 @@ class KmpComponentCreateGenerator(
             packageName = componentClass.packageName,
             fileName = "KmpComponentCreate${componentClass.name}",
         ).apply {
+            addAnnotation(createSuppressAnnotation("REDUNDANT_VISIBILITY_MODIFIER"))
             kmpComponentCreateFunctions.forEach { kmpComponentCreateFunction ->
                 addFunction(
                     FunSpec


### PR DESCRIPTION
Fix for #459

![image](https://github.com/user-attachments/assets/1ffc1b46-be55-4c91-9edb-cd4ae2eac235)

![image](https://github.com/user-attachments/assets/f0b7fec3-9a47-42bc-8879-c707c11c3ccb)
