### PR TITLE
Add support for IntoSet/Map(multiple = true)

### DIFF
--- a/integration-tests/common/src/main/kotlin/me/tatarka/inject/test/Multibinds.kt
+++ b/integration-tests/common/src/main/kotlin/me/tatarka/inject/test/Multibinds.kt
@@ -25,6 +25,15 @@ abstract class SetComponent {
 }
 
 @Component
+abstract class EmptySetComponent {
+    abstract val items: Set<FooValue>
+
+    @Provides
+    @IntoSet(multiple = true)
+    fun defaultEmptySet() = emptySet<FooValue>()
+}
+
+@Component
 abstract class DynamicKeyComponent {
 
     abstract val items: Map<String, FooValue>
@@ -35,6 +44,10 @@ abstract class DynamicKeyComponent {
 
     val fooValue2
         @Provides @IntoMap get() = "2" to FooValue("2")
+
+    @Provides
+    @IntoMap(multiple = true)
+    fun fooValue3And4() = mapOf("3" to FooValue("3"), "4" to FooValue("4"))
 }
 
 @Component

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/InjectGenerator.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/InjectGenerator.kt
@@ -31,6 +31,7 @@ val SCOPE = ClassName(ANNOTATION_PACKAGE_NAME, "Scope")
 val INJECT = ClassName(ANNOTATION_PACKAGE_NAME, "Inject")
 val INTO_MAP = ClassName(ANNOTATION_PACKAGE_NAME, "IntoMap")
 val INTO_SET = ClassName(ANNOTATION_PACKAGE_NAME, "IntoSet")
+const val ANNOTATION_MULTIPLE_ARG = "multiple"
 val ASSISTED = ClassName(ANNOTATION_PACKAGE_NAME, "Assisted")
 val ASSISTED_FACTORY = ClassName(ANNOTATION_PACKAGE_NAME, "AssistedFactory")
 const val ASSISTED_FACTORY_FUNCTION_ARG = "injectFunction"
@@ -226,6 +227,19 @@ fun AstAnnotated.isAssistedFactory() = hasAnnotation(ASSISTED_FACTORY)
 fun AstAnnotated.assistedFactoryFunctionName() =
     annotation(ASSISTED_FACTORY.packageName, ASSISTED_FACTORY.simpleName)
         ?.argument(ASSISTED_FACTORY_FUNCTION_ARG) as? String
+
+fun AstAnnotated.isIntoMap() = hasAnnotation(INTO_MAP)
+
+fun AstAnnotated.isIntoSet() = hasAnnotation(INTO_SET)
+
+private fun AstAnnotated.multipleArgValue(annotationClass: ClassName) =
+    annotation(annotationClass.packageName, annotationClass.simpleName)
+        ?.argument(ANNOTATION_MULTIPLE_ARG) as Boolean?
+        ?: false
+
+fun AstAnnotated.isIntoMapMultiple() = multipleArgValue(INTO_MAP)
+
+fun AstAnnotated.isIntoSetMultiple() = multipleArgValue(INTO_SET)
 
 fun AstClass.findInjectConstructors(messenger: Messenger, options: Options): AstConstructor? {
     val injectCtors = constructors.filter {

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResult.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResult.kt
@@ -80,11 +80,14 @@ sealed class TypeResult {
             }
     }
 
-    /**
-     * A container that holds the type (ex: Set or Map).
-     */
-    class Container(
-        val creator: String,
+    class SetContainer(
+        val args: List<TypeResultRef>,
+    ) : TypeResult() {
+        override val children
+            get() = args.iterator()
+    }
+
+    class MapContainer(
         val args: List<TypeResultRef>,
     ) : TypeResult() {
         override val children

--- a/kotlin-inject-runtime/src/commonMain/kotlin/me/tatarka/inject/annotations/Annotations.kt
+++ b/kotlin-inject-runtime/src/commonMain/kotlin/me/tatarka/inject/annotations/Annotations.kt
@@ -20,10 +20,10 @@ annotation class Provides
 annotation class Scope
 
 @Target(FUNCTION, PROPERTY_GETTER)
-annotation class IntoSet
+annotation class IntoSet(val multiple: Boolean = false)
 
 @Target(FUNCTION, PROPERTY_GETTER)
-annotation class IntoMap
+annotation class IntoMap(val multiple: Boolean = false)
 
 @Target(VALUE_PARAMETER)
 annotation class Assisted


### PR DESCRIPTION
Fixes https://github.com/evant/kotlin-inject/issues/249

Initial stab at implementing. Haven't added significant tests or updated any docs.

A few notes:

### IntoSet
This changes the `IntoSet` implementation from `setOf()` to something like: 
```kotlin
buildSet(3) {
  add(itemOne())
  add(itemTwo)
  addAll(itemThreeAndFour())
}
```
* `3` here is just the number of providers -- we can't know how many items a `multiple = true` could provide, so our guess is just 1 item per provider. This is the same as what dagger generates for `@ElementsIntoSet`
* We have to use `add` and `addAll` to properly distinguish between a `multiple = true` value and a `multiple = false` value

### IntoMap
Similarly, this changes the `IntoMap` implementation from `mapOf()` to something like:
```kotlin
buildMap(3) {
  this += pairOne()
  this += pairTwo()
  this += mapOfThreeAndFour()
}
```
* In this case, we can use the `+=` operator since we know the values are either `Pair` or `Map` -- it's unambiguous.

### IntoSet(multiple = True) w/ Lazy or Functions
If you have a binding of `Set<Lazy<String>>` or `Set<() -> String>`, along with an `IntoSet(multiple = True)`, I'm not sure what is expected. Wrapping the provider with `lazy` wouldn't work -- we'd have to actually evaluate the provider anyway. For now I fail fast with an error.