### PR TITLE
update readme documentation for assisted injection to cover the assisted factory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.idea/*
 !/.idea/codeStyles
 /.kotlin
+local.properties

--- a/README.md
+++ b/README.md
@@ -406,16 +406,21 @@ class MyClass(fooCreator: () -> Foo) {
 ```
 
 If you define args, you can use these to assist the creation of the dependency. To do so, mark these args with the
-`@Assisted` annotation. The function should take the same number of assisted args in the same order.
+`@Assisted` annotation. Then create an interface with the `@AssistedFactory` annotation with a function that takes the same number of assisted args in the same order.
 
 ```kotlin
 @Inject
 class Foo(bar: Bar, @Assisted arg1: String, @Assisted arg2: String)
 
+@AssistedFactory
+interface FooFactory {
+    fun create(arg1: String, arg2: String): Foo
+}
+
 @Inject
-class MyClass(fooCreator: (arg1: String, arg2: String) -> Foo) {
+class MyClass(fooFactory: FooFactory) {
     init {
-        val foo = fooCreator("1", "2")
+        val foo = fooFactory.create("1", "2")
     }
 }
 ```


### PR DESCRIPTION
I just noticed the use of `@AssistedFactory` in the [sample](https://github.com/evant/kotlin-inject/blob/main/integration-tests/common/src/main/kotlin/me/tatarka/inject/test/Assisted.kt#L27), but didn't see it well documented. So I updated the readme to explain the usage of this. 