### PR TITLE
Fixed code generation when referecning a parent component provider that

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed code generation when referencing a parent component provider that uses a receiver.
+
 ## [0.8.0] - 2025-04-27
 
 ### Changed

--- a/integration-tests/common-test/src/test/kotlin/me/tatarka/inject/test/NestedComponentTest.kt
+++ b/integration-tests/common-test/src/test/kotlin/me/tatarka/inject/test/NestedComponentTest.kt
@@ -13,6 +13,7 @@ class NestedComponentTest {
 
         assertThat(component.parent.parentNamedFoo.name).isEqualTo("parent")
         assertThat(component.namedFoo.name).isEqualTo("parent")
+        assertThat(component.namedBar.name).isEqualTo("parent")
         assertThat(component.foo).isNotNull()
     }
 
@@ -24,6 +25,7 @@ class NestedComponentTest {
 
         assertThat(component.parent.parent.parentNamedFoo.name).isEqualTo("parent")
         assertThat(component.namedFoo.name).isEqualTo("parent")
+        assertThat(component.namedBar.name).isEqualTo("parent")
         assertThat(component.foo).isNotNull()
         assertThat(component.bar).isNotNull()
     }

--- a/integration-tests/common/src/main/kotlin/me/tatarka/inject/test/NestedComponent.kt
+++ b/integration-tests/common/src/main/kotlin/me/tatarka/inject/test/NestedComponent.kt
@@ -9,12 +9,20 @@ import me.tatarka.inject.annotations.Provides
     @Provides
     protected fun foo() = NamedFoo("parent")
 
+    @Provides
+    fun bar() = NamedBar("parent")
+
     val Foo.binds: IFoo
+        @Provides get() = this
+
+    val NamedBar.binds: INamedBar
         @Provides get() = this
 }
 
 @Component abstract class SimpleChildComponent1(@Component val parent: ParentComponent) {
     abstract val namedFoo: NamedFoo
+
+    abstract val namedBar: INamedBar
 
     val BarImpl.binds: IBar
         @Provides get() = this
@@ -24,6 +32,8 @@ import me.tatarka.inject.annotations.Provides
 
 @Component abstract class SimpleChildComponent2(@Component val parent: SimpleChildComponent1) {
     abstract val namedFoo: NamedFoo
+
+    abstract val namedBar: INamedBar
 
     abstract val foo: IFoo
 

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultGenerator.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultGenerator.kt
@@ -108,7 +108,9 @@ data class TypeResultGenerator(val options: Options, val implicitAccessor: Acces
                     add("%L.", accessorInScope)
                 }
             } else if (implicitAccessor.isNotEmpty()) {
-                add("this@%L.", className)
+                if (accessor == accessorInScope) {
+                    add("this@%L.", className)
+                }
             }
 
             if (receiver != null) {


### PR DESCRIPTION
uses a receiver

Fixes: #487