### PR TITLE
Fix code generation when using receiver bindings and @AssistedFactory

### DIFF
--- a/integration-tests/common/src/main/kotlin/me/tatarka/inject/test/Assisted.kt
+++ b/integration-tests/common/src/main/kotlin/me/tatarka/inject/test/Assisted.kt
@@ -19,7 +19,7 @@ class SomethingProvided()
 @Inject
 class FactoryAssistedBar(
     @Assisted val num: Int,
-    val foo: Foo,
+    val foo: IFoo,
     @Assisted val name: String,
     val provided: SomethingProvided,
 )
@@ -36,6 +36,12 @@ class SomethingDependantOnAssistedFactory(val factory: AssistedBarFactory)
 abstract class AssistedFactoryComponent {
     abstract val barFactory: AssistedBarFactory
     abstract val somethingDependant: SomethingDependantOnAssistedFactory
+
+    @Provides
+    fun provideFoo(): Foo = Foo()
+
+    val Foo.bind: IFoo
+        @Provides get() = this
 
     @get:Provides
     val name: SomethingProvided = SomethingProvided() // makes sure names don't clash with assisted params

--- a/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultGenerator.kt
+++ b/kotlin-inject-compiler/core/src/main/kotlin/me/tatarka/inject/compiler/TypeResultGenerator.kt
@@ -107,8 +107,9 @@ data class TypeResultGenerator(val options: Options, val implicitAccessor: Acces
                     }
                     add("%L.", accessorInScope)
                 }
-            } else if (implicitAccessor.isNotEmpty()) {
-                if (accessor == accessorInScope) {
+            } else if (implicitAccessor.isNotEmpty() && accessor == accessorInScope) {
+                // `receiver` will generate its own `this` expression below
+                if (receiver == null) {
                     add("this@%L.", className)
                 }
             }


### PR DESCRIPTION
The code generation would sometimes double the `this` expressions

```kotlin
public class InjectAssistedFactoryComponent : AssistedFactoryComponent() {
  override val barFactory: AssistedBarFactory
    get() = object : AssistedBarFactory {
      override fun build(num: Int, name: String): FactoryAssistedBar = FactoryAssistedBar(
        num = num,

        // compilation failure here
        foo = this@InjectAssistedFactoryComponent.this@InjectAssistedFactoryComponent.provideFoo().bind,

        name = name,
        provided = this@InjectAssistedFactoryComponent.name
      )
    }
```

Continuation for [#487](https://github.com/evant/kotlin-inject/issues/487#issuecomment-2849098544)