### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,9 @@ jobs:
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRO }}
+
+      - name: Set up gradle
+        uses: gradle/actions/setup-gradle@8379f6a1328ee0e06e2bb424dadb7b159856a326 # v4.4.0
       
       - name: Build ${{ matrix.os }}
         run: ./gradlew assemble

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,72 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+env:
+  JAVA_VERSION: 22
+  JAVA_DISTRO: 'temurin'
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@8379f6a1328ee0e06e2bb424dadb7b159856a326 # v4.4.0
+
+      - name: Set up JDK
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRO }}
+      
+      - name: Build ${{ matrix.os }}
+        run: ./gradlew assemble
+
+      - name: Compile Linux Test
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          ./gradlew linkDebugTestLinuxX64 linkDebugTestMingwX64 compileTestDevelopmentExecutableKotlinJs compileTestDevelopmentExecutableKotlinWasmJs
+
+      - name: Run Linux Test
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          ./gradlew check --continue -x jsBrowserTest -x wasmJsBrowserTest
+
+      - name: Run Linux Browser Tests
+        if: startsWith(matrix.os, 'ubuntu')
+        run: ./gradlew jsBrowserTest -x wasmJsBrowserTest
+      
+      - name: Run MacOS Test
+        if: startsWith(matrix.os, 'macos')
+        run: ./gradlew checkApple --continue
+      
+  # publish:
+  #   if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  #   runs-on: ubuntu-latest
+  #   needs: build
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+  #     - name: Set up JDK
+  #       uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+  #       with:
+  #         java-version: ${{ env.JAVA_VERSION }}
+  #         distribution: ${{ env.JAVA_DISTRO }}
+
+      

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ concurrency:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/.gitignore'
+      - '**.md'
   pull_request:
+    paths-ignore:
+      - '**/.gitignore'
+      - '**.md'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,20 +65,11 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: ./gradlew checkApple --continue
       
-      - name: Upload Linux test results
-        if: always() && startsWith(matrix.os, 'ubuntu')
+      - name: Upload test results
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: test-results-linux-publish
-          path: |
-            build/test-results
-            build/reports
-      
-      - name: Upload MacOS test results
-        if: always() && startsWith(matrix.os, 'macos')
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: test-results-macos-publish
+          name: test-results-${{ matrix.os }}-publish
           path: |
             build/test-results
             build/reports

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,24 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: ./gradlew checkApple --continue
       
+      - name: Upload Linux test results
+        if: always() && startsWith(matrix.os, 'ubuntu')
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-results-linux-publish
+          path: |
+            build/test-results
+            build/reports
+      
+      - name: Upload MacOS test results
+        if: always() && startsWith(matrix.os, 'macos')
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-results-macos-publish
+          path: |
+            build/test-results
+            build/reports
+      
   # publish:
   #   if: github.event_name == 'push' && github.ref == 'refs/heads/main'
   #   runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,18 +73,12 @@ jobs:
             build/test-results
             build/reports
       
-  # publish:
-  #   if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-  #   runs-on: ubuntu-latest
-  #   needs: build
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-  #     - name: Set up JDK
-  #       uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
-  #       with:
-  #         java-version: ${{ env.JAVA_VERSION }}
-  #         distribution: ${{ env.JAVA_DISTRO }}
-
+      # - name: Publish Linux
+      #   if: startsWith(matrix.os, 'ubuntu') && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      #   run: |
+      #     ./gradlew publishLinux
       
+      # - name: Publish MacOS
+      #   if: startsWith(matrix.os, 'macos') && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      #   run: |
+      #     ./gradlew publishMacos      

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRO }}
+          
+      - name: Set up gradle
+        uses: gradle/actions/setup-gradle@8379f6a1328ee0e06e2bb424dadb7b159856a326 # v4.4.0
 
       - name: Check code
         run: ./gradlew detekt

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,31 @@
+name: Check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+env:
+  JAVA_VERSION: 22
+  JAVA_DISTRO: 'temurin'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@8379f6a1328ee0e06e2bb424dadb7b159856a326 # v4.4.0
+
+      - name: Set up JDK
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRO }}
+
+      - name: Check code
+        run: ./gradlew detekt

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/.gitignore'
+      - '**.md'
   pull_request:
+    paths-ignore:
+      - '**/.gitignore'
+      - '**.md'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Hello

was thinking of checking kotlin-inject for migration of my android project into KMP and then I saw https://github.com/evant/kotlin-inject/discussions/486 and figured I can do the simple stuff of building initial setup of Github actions and let you take care of the publishing and other complex stuff.

---

Changes made with this PR
- Enabled build whenever there is a push on the `main` branch or in a `pull_request` can also manually building at the actions tab
- Made the concurrency to cancel other build if done not on the main branch
- Setup a matrix so the `macos` and `ubuntu` can run in parallel
- Did not explicitly added the chrome and chrome drivers as it is already on the runner-images
  - https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#browsers-and-drivers
  - https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#browsers
- Make use of git hash for the version control of github actions for security
- Added ability to ignore when you update a markdown and the gitignore
- `gradle-wrapper-validation` for validating you got true gradle wrapper https://github.com/gradle/actions/blob/main/docs/wrapper-validation.md#gradle-wrapper-validation-action
- `setup-gradle` was added so you can cache the build. By default it will only cache the default branch and other branches will only be a read only to it https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#using-the-cache-read-only

I also made another workflow for lint check. This one will always run on all of the commits in the `pull request` and pushes to `main` branch